### PR TITLE
ldapadmin contextpath normalized

### DIFF
--- a/ldapadmin/ldapadmin.properties
+++ b/ldapadmin/ldapadmin.properties
@@ -1,5 +1,5 @@
 # general purposes properties
-publicContextPath=/ldapadmin/
+publicContextPath=/ldapadmin
 protectedUser.uid1=geoserver_privileged_user
 moderatedSignup=true
 moderatorEmail=georchestra+testadmin@georchestra.mydomain.org


### PR DESCRIPTION
publicContextPath should be the same as shared.ldapadmin.contextpath, see https://github.com/georchestra/georchestra/blob/15.06/config/shared.maven.filters#L61