### PR TITLE
console appenders everywhere with docker

### DIFF
--- a/analytics/log4j/log4j.properties
+++ b/analytics/log4j/log4j.properties
@@ -1,12 +1,8 @@
-log4j.rootLogger=WARN, R
+log4j.rootLogger=WARN, S
 
-log4j.logger.org.georchestra.analytics=WARN, R
+log4j.logger.org.georchestra.analytics=WARN, S
 
-log4j.appender.R = org.apache.log4j.rolling.RollingFileAppender
-log4j.appender.R.RollingPolicy = org.apache.log4j.rolling.TimeBasedRollingPolicy
-log4j.appender.R.RollingPolicy.FileNamePattern = /tmp/analytics.%d.log.gz
-log4j.appender.R.RollingPolicy.ActiveFileName = /tmp/analytics.log
-log4j.appender.R.Append = true
-log4j.appender.R.layout = org.apache.log4j.PatternLayout
-log4j.appender.R.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n
-
+log4j.appender.S = org.apache.log4j.ConsoleAppender
+log4j.appender.S.Append = true
+log4j.appender.S.layout = org.apache.log4j.PatternLayout
+log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/analytics/log4j/log4j.properties
+++ b/analytics/log4j/log4j.properties
@@ -3,6 +3,5 @@ log4j.rootLogger=WARN, S
 log4j.logger.org.georchestra.analytics=WARN, S
 
 log4j.appender.S = org.apache.log4j.ConsoleAppender
-log4j.appender.S.Append = true
 log4j.appender.S.layout = org.apache.log4j.PatternLayout
 log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/catalogapp/log4j/log4j.properties
+++ b/catalogapp/log4j/log4j.properties
@@ -1,11 +1,8 @@
-log4j.rootLogger=WARN, R
+log4j.rootLogger=WARN, S
 
-log4j.logger.catalogapp=WARN, R
+log4j.logger.org.georchestra.catalogapp=WARN, S
 
-log4j.appender.R = org.apache.log4j.rolling.RollingFileAppender
-log4j.appender.R.RollingPolicy = org.apache.log4j.rolling.TimeBasedRollingPolicy
-log4j.appender.R.RollingPolicy.FileNamePattern = /tmp/catalogapp.%d.log.gz
-log4j.appender.R.RollingPolicy.ActiveFileName = /tmp/catalogapp.log
-log4j.appender.R.Append = true
-log4j.appender.R.layout = org.apache.log4j.PatternLayout
-log4j.appender.R.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n
+log4j.appender.S = org.apache.log4j.ConsoleAppender
+log4j.appender.S.Append = true
+log4j.appender.S.layout = org.apache.log4j.PatternLayout
+log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/catalogapp/log4j/log4j.properties
+++ b/catalogapp/log4j/log4j.properties
@@ -3,6 +3,5 @@ log4j.rootLogger=WARN, S
 log4j.logger.org.georchestra.catalogapp=WARN, S
 
 log4j.appender.S = org.apache.log4j.ConsoleAppender
-log4j.appender.S.Append = true
 log4j.appender.S.layout = org.apache.log4j.PatternLayout
 log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/downloadform/log4j/log4j.properties
+++ b/downloadform/log4j/log4j.properties
@@ -1,9 +1,8 @@
-log4j.rootLogger=WARN, R
+log4j.rootLogger=WARN, S
 
-log4j.logger.downloadform=WARN, R
+log4j.logger.org.georchestra.downloadform=WARN, S
 
-log4j.appender.R = org.apache.log4j.ConsoleAppender
-log4j.appender.R.Append = true
-log4j.appender.R.layout = org.apache.log4j.PatternLayout
-log4j.appender.R.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n
-
+log4j.appender.S = org.apache.log4j.ConsoleAppender
+log4j.appender.S.Append = true
+log4j.appender.S.layout = org.apache.log4j.PatternLayout
+log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/downloadform/log4j/log4j.properties
+++ b/downloadform/log4j/log4j.properties
@@ -3,6 +3,5 @@ log4j.rootLogger=WARN, S
 log4j.logger.org.georchestra.downloadform=WARN, S
 
 log4j.appender.S = org.apache.log4j.ConsoleAppender
-log4j.appender.S.Append = true
 log4j.appender.S.layout = org.apache.log4j.PatternLayout
 log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/extractorapp/log4j/log4j.properties
+++ b/extractorapp/log4j/log4j.properties
@@ -14,15 +14,12 @@
 #      FATAL, ERROR, WARN, INFO, DEBUG
 #
 #------------------------------------------------------------------------------
-log4j.rootLogger=WARN, R
+log4j.rootLogger=WARN, S
 
-log4j.logger.org.georchestra.extractorapp=WARN, R
-log4j.logger.org.geotools=WARN, R
+log4j.logger.org.georchestra.extractorapp=WARN, S
+log4j.logger.org.geotools=WARN, S
 
-log4j.appender.R = org.apache.log4j.rolling.RollingFileAppender
-log4j.appender.R.RollingPolicy = org.apache.log4j.rolling.TimeBasedRollingPolicy
-log4j.appender.R.RollingPolicy.FileNamePattern = /tmp/extractorapp.%d.log.gz
-log4j.appender.R.RollingPolicy.ActiveFileName = /tmp/extractorapp.log
-log4j.appender.R.Append = true
-log4j.appender.R.layout = org.apache.log4j.PatternLayout
-log4j.appender.R.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n
+log4j.appender.S = org.apache.log4j.ConsoleAppender
+log4j.appender.S.Append = true
+log4j.appender.S.layout = org.apache.log4j.PatternLayout
+log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/extractorapp/log4j/log4j.properties
+++ b/extractorapp/log4j/log4j.properties
@@ -20,6 +20,5 @@ log4j.logger.org.georchestra.extractorapp=WARN, S
 log4j.logger.org.geotools=WARN, S
 
 log4j.appender.S = org.apache.log4j.ConsoleAppender
-log4j.appender.S.Append = true
 log4j.appender.S.layout = org.apache.log4j.PatternLayout
 log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/geowebcache/log4j/log4j.properties
+++ b/geowebcache/log4j/log4j.properties
@@ -1,13 +1,9 @@
-log4j.rootLogger=WARN, R
+log4j.rootLogger=WARN, S
 
-log4j.category.org.geowebcache.seed=WARN, R
-log4j.category.org.geowebcache.diskquota=WARN, R
+log4j.category.org.geowebcache.seed=WARN, S
+log4j.category.org.geowebcache.diskquota=WARN, S
 
-log4j.appender.R = org.apache.log4j.rolling.RollingFileAppender
-log4j.appender.R.RollingPolicy = org.apache.log4j.rolling.TimeBasedRollingPolicy
-log4j.appender.R.RollingPolicy.FileNamePattern = /tmp/geowebcache/geowebcache.%d.log.gz
-log4j.appender.R.RollingPolicy.ActiveFileName = /tmp/geowebcache.log
-log4j.appender.R.Append = true
-log4j.appender.R.layout = org.apache.log4j.PatternLayout
-log4j.appender.R.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n
-
+log4j.appender.S = org.apache.log4j.ConsoleAppender
+log4j.appender.S.Append = true
+log4j.appender.S.layout = org.apache.log4j.PatternLayout
+log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/geowebcache/log4j/log4j.properties
+++ b/geowebcache/log4j/log4j.properties
@@ -4,6 +4,5 @@ log4j.category.org.geowebcache.seed=WARN, S
 log4j.category.org.geowebcache.diskquota=WARN, S
 
 log4j.appender.S = org.apache.log4j.ConsoleAppender
-log4j.appender.S.Append = true
 log4j.appender.S.layout = org.apache.log4j.PatternLayout
 log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/header/log4j/log4j.properties
+++ b/header/log4j/log4j.properties
@@ -3,6 +3,5 @@ log4j.rootLogger=WARN, S
 log4j.logger.org.georchestra.header=WARN, S
 
 log4j.appender.S = org.apache.log4j.ConsoleAppender
-log4j.appender.S.Append = true
 log4j.appender.S.layout = org.apache.log4j.PatternLayout
 log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/header/log4j/log4j.properties
+++ b/header/log4j/log4j.properties
@@ -1,8 +1,8 @@
-log4j.rootLogger=WARN, R
+log4j.rootLogger=WARN, S
 
-log4j.logger.header=WARN, R
+log4j.logger.org.georchestra.header=WARN, S
 
-log4j.appender.R = org.apache.log4j.ConsoleAppender
-log4j.appender.R.Append = true
-log4j.appender.R.layout = org.apache.log4j.PatternLayout
-log4j.appender.R.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n
+log4j.appender.S = org.apache.log4j.ConsoleAppender
+log4j.appender.S.Append = true
+log4j.appender.S.layout = org.apache.log4j.PatternLayout
+log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/ldapadmin/log4j/log4j.properties
+++ b/ldapadmin/log4j/log4j.properties
@@ -20,6 +20,5 @@ log4j.logger.org.georchestra.ldapadmin=WARN, S
 log4j.logger.org.georchestra.ldapadmin.ws.utils=INFO, S
 
 log4j.appender.S = org.apache.log4j.ConsoleAppender
-log4j.appender.S.Append = true
 log4j.appender.S.layout = org.apache.log4j.PatternLayout
 log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/ldapadmin/log4j/log4j.properties
+++ b/ldapadmin/log4j/log4j.properties
@@ -14,16 +14,12 @@
 #      FATAL, ERROR, WARN, INFO, DEBUG
 #
 #------------------------------------------------------------------------------
-log4j.rootLogger=WARN, R
+log4j.rootLogger=WARN, S
 
-log4j.logger.org.georchestra.ldapadmin=WARN, R
-log4j.logger.org.georchestra.ldapadmin.ws.utils=INFO, R
+log4j.logger.org.georchestra.ldapadmin=WARN, S
+log4j.logger.org.georchestra.ldapadmin.ws.utils=INFO, S
 
-log4j.appender.R = org.apache.log4j.rolling.RollingFileAppender
-log4j.appender.R.RollingPolicy = org.apache.log4j.rolling.TimeBasedRollingPolicy
-log4j.appender.R.RollingPolicy.FileNamePattern = /tmp/ldapadmin.%d.log.gz
-log4j.appender.R.RollingPolicy.ActiveFileName = /tmp/ldapadmin.log
-log4j.appender.R.Append = true
-log4j.appender.R.layout = org.apache.log4j.PatternLayout
-log4j.appender.R.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n
-
+log4j.appender.S = org.apache.log4j.ConsoleAppender
+log4j.appender.S.Append = true
+log4j.appender.S.layout = org.apache.log4j.PatternLayout
+log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/mapfishapp/log4j/log4j.properties
+++ b/mapfishapp/log4j/log4j.properties
@@ -5,6 +5,5 @@ log4j.logger.org.mapfish.print=WARN, S
 log4j.logger.org.geotools=WARN, S
 
 log4j.appender.S = org.apache.log4j.ConsoleAppender
-log4j.appender.S.Append = true
 log4j.appender.S.layout = org.apache.log4j.PatternLayout
 log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/mapfishapp/log4j/log4j.properties
+++ b/mapfishapp/log4j/log4j.properties
@@ -1,11 +1,10 @@
-log4j.rootLogger=INFO, R
+log4j.rootLogger=WARN, S
 
-log4j.logger.mapfishapp=INFO, R
-log4j.logger.org.mapfish.print=INFO, R
-log4j.logger.org.geotools=INFO, R
+log4j.logger.org.georchestra.mapfishapp=WARN, S
+log4j.logger.org.mapfish.print=WARN, S
+log4j.logger.org.geotools=WARN, S
 
-log4j.appender.R = org.apache.log4j.ConsoleAppender
-log4j.appender.R.Append = true
-log4j.appender.R.layout = org.apache.log4j.PatternLayout
-log4j.appender.R.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n
-
+log4j.appender.S = org.apache.log4j.ConsoleAppender
+log4j.appender.S.Append = true
+log4j.appender.S.layout = org.apache.log4j.PatternLayout
+log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/security-proxy/log4j/log4j.properties
+++ b/security-proxy/log4j/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=INFO, R
+log4j.rootLogger=INFO, S
 
 log4j.logger.org.georchestra.security=INFO
 log4j.logger.org.georchestra.security.statistics=INFO, OGCSTATISTICS
@@ -10,9 +10,9 @@ log4j.logger.org.springframework=INFO
 log4j.logger.org.springframework.security=INFO
 log4j.logger.org.jasig=INFO
 
-log4j.appender.R = org.apache.log4j.ConsoleAppender
-log4j.appender.R.layout = org.apache.log4j.PatternLayout
-log4j.appender.R.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n
+log4j.appender.S = org.apache.log4j.ConsoleAppender
+log4j.appender.S.layout = org.apache.log4j.PatternLayout
+log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n
 
 # network socket (Logstash / Elasticsearch)
 #log4j.appender.NETWORKSOCKET=org.apache.log4j.net.SocketAppender
@@ -25,4 +25,3 @@ log4j.appender.OGCSTATISTICS.activated=true
 log4j.appender.OGCSTATISTICS.jdbcURL=jdbc:postgresql://database:5432/georchestra
 log4j.appender.OGCSTATISTICS.databaseUser=georchestra
 log4j.appender.OGCSTATISTICS.databasePassword=georchestra
-


### PR DESCRIPTION
This PR:
 * replaces remaining `RollingFileAppender` with `ConsoleAppender` where applicable
 * replaces the `R` appender with `S` (for console) 
 * normalizes logger names, eg `log4j.logger.catalogapp` -> `log4j.logger.org.georchestra.catalogapp`

To be cascade-merged into the `docker-master` branch after acceptance.

Please review.