### PR TITLE
setting a fqdn to the reverse-proxy

### DIFF
--- a/cas/cas.properties
+++ b/cas/cas.properties
@@ -1,8 +1,8 @@
-server.name=http://localhost:8080
-server.prefix=http://localhost:8080/cas
+server.name=http://georchestra.mydomain.org
+server.prefix=http://georchestra.mydomain.org/cas
 instance.name=geOrchestra on docker
 
-homepage.url=http://localhost:8080/header/
+homepage.url=http://georchestra.mydomain.org/header/
 header.height=90
 
 # IP address or CIDR subnet allowed to access the /status URI of CAS that exposes health check information
@@ -17,7 +17,7 @@ cas.viewResolver.basename=default_views
 # Unique CAS node name
 # host.name is used to generate unique Service Ticket IDs and SAMLArtifacts.  This is usually set to the specific
 # hostname of the machine running the CAS node, but it could be any label so long as it is unique in the cluster.
-host.name=localhost:8080
+host.name=georchestra.mydomain.org
 
 ldap.url=ldap://ldap:389
 ldap.authn.groupSearchBaseDn=ou=roles,dc=georchestra,dc=org

--- a/security-proxy/security-proxy.properties
+++ b/security-proxy/security-proxy.properties
@@ -1,5 +1,5 @@
 # ------   proxy-servlet.xml   ---------
-public.host=http://localhost:8080/
+public.host=http://georchestra.mydomain.org/
 # default timeout : 20min should be enough to handle big extraction (~ 4x10^9 pixels)
 http_client_timeout=1200000
 
@@ -7,13 +7,13 @@ http_client_timeout=1200000
 anonymousRole=ROLE_ANONYMOUS
 proxy.contextPath=/sec
 # url called when user has logged out
-logout-success-url=http://localhost:8080/cas/logout?fromgeorchestra
+logout-success-url=http://georchestra.mydomain.org/cas/logout?fromgeorchestra
 # url where the user can login
-casLoginUrl=http://localhost:8080/cas/login
+casLoginUrl=http://georchestra.mydomain.org/cas/login
 # url that the security system uses to validate the cas tickets
 casTicketValidation=http://cas:8080/cas
 # After going to the cas login cas forwards to this URL where the authorities and permissions are checked
-proxyCallback=http://localhost:8080/j_spring_cas_security_check
+proxyCallback=http://georchestra.mydomain.org/j_spring_cas_security_check
 # the ldap url
 ldapUrl=ldap://ldap
 baseDN=dc=georchestra,dc=org


### PR DESCRIPTION
Since [Traefik](https://traefik.io/) is used as frontend, we should instruct containers to use a FQDN rather than `localhost:8080`.