### PR TITLE
security-proxy - Remove sec-orgname header

### DIFF
--- a/security-proxy/headers-mapping.properties
+++ b/security-proxy/headers-mapping.properties
@@ -1,5 +1,4 @@
 sec-email=mail
 sec-firstname=givenName
 sec-lastname=sn
-sec-orgname=o
 sec-tel=telephoneNumber


### PR DESCRIPTION
This header will be added in LdapUserDetailsRequestHeaderProvider with the human
readable name of org from ou=orgs objects.