### PR TITLE
GeoNetwork groups now synced with LDAP Orgs

### DIFF
--- a/geonetwork/config/config-security-georchestra.xml
+++ b/geonetwork/config/config-security-georchestra.xml
@@ -89,9 +89,9 @@
     <property name="createNonExistingLdapGroup" value="${ldap.privilege.create.nonexisting.roles}"/>
     <property name="createNonExistingLdapUser" value="${ldap.privilege.create.nonexisting.users}"/>
     <property name="ldapManager" ref="ldapUserDetailsService"/>
-    <property name="groupAttribute" value="${ldap.privilege.search.role.attribute}"/>
-    <property name="groupObject" value="${ldap.privilege.search.role.object}"/>
-    <property name="groupQuery" value="${ldap.privilege.search.role.query}"/>
+    <property name="groupAttribute" value="${ldap.privilege.search.group.attribute}"/>
+    <property name="groupObject" value="${ldap.privilege.search.group.object}"/>
+    <property name="groupQuery" value="${ldap.privilege.search.group.query}"/>
     <property name="groupQueryPattern" value="${ldap.privilege.search.privilege.pattern}"/>
     <property name="privilegeAttribute" value="${ldap.privilege.search.privilege.attribute}"/>
     <property name="privilegeObject" value="${ldap.privilege.search.privilege.object}"/>
@@ -132,9 +132,9 @@
   </bean>
   <bean id="ldapUserDetailsService" class="org.fao.geonet.kernel.security.ldap.LdapUserDetailsManager">
     <constructor-arg ref="contextSource"/>
-    <constructor-arg name="groupMemberAttributeName" value="${ldap.privilege.search.role.queryprop}"/>
-    <constructor-arg name="query" value="${ldap.privilege.search.role.query}"/>
-    <property name="groupSearchBase" value="${ldap.privilege.search.role.object}"/>
+    <constructor-arg name="groupMemberAttributeName" value="${ldap.privilege.search.group.queryprop}"/>
+    <constructor-arg name="query" value="${ldap.privilege.search.group.query}"/>
+    <property name="groupSearchBase" value="${ldap.privilege.search.group.object}"/>
     <property name="usernameMapper" ref="usernameMapper"/>
     <property name="userDetailsMapper" ref="ldapUserContextMapper"/>
   </bean>

--- a/geonetwork/geonetwork.properties
+++ b/geonetwork/geonetwork.properties
@@ -45,10 +45,10 @@ ldap.sync.cron=0 * * * * ?
 ldap.sync.startDelay=60000
 
 ldap.privilege.import=true
-ldap.privilege.search.role.queryprop=member
-ldap.privilege.search.role.query=(&(objectClass=groupOfMembers)(member=uid={0},${ldap.base.search.base},${ldap.base.dn})(cn=EL_*))
-ldap.privilege.search.role.object=ou=roles
 ldap.base.search.base=ou=users
+ldap.privilege.search.group.queryprop=member
+ldap.privilege.search.group.query=(&(objectClass=groupOfMembers)(member=uid={0},${ldap.base.search.base},${ldap.base.dn}))
+ldap.privilege.search.group.object=ou=orgs
 ldap.privilege.search.privilege.pattern=GN_(.*)
 ldap.privilege.search.privilege.query=(&(objectClass=groupOfMembers)(member=uid={0},${ldap.base.search.base},${ldap.base.dn}))
 ldap.privilege.search.privilege.object=ou=roles


### PR DESCRIPTION
A proposal for https://github.com/georchestra/georchestra/issues/1682

This should be the default in geOrchestra IMO, now that we have true Orgs: no need to depend anymore on EL_* roles.

If accepted, this should be documented in the release + migration notes