### PR TITLE
SP - fix cas behind SP

### DIFF
--- a/security-proxy/security-mappings.xml
+++ b/security-proxy/security-mappings.xml
@@ -1,6 +1,6 @@
 <http>
+  <intercept-url pattern="/cas/login.*" access="IS_AUTHENTICATED_ANONYMOUSLY" />
   <intercept-url pattern=".*\?.*login.*" access="ROLE_USER,ROLE_GN_EDITOR,ROLE_GN_REVIEWER,ROLE_GN_ADMIN,ROLE_ADMINISTRATOR" />
-  <intercept-url pattern=".*\?.*casLogin.*" access="ROLE_USER,ROLE_GN_EDITOR,ROLE_GN_REVIEWER,ROLE_GN_ADMIN,ROLE_ADMINISTRATOR" />
   <intercept-url pattern="/extractorapp/admin.*" access="ROLE_ADMINISTRATOR" />
   <intercept-url pattern="/extractorapp/jobs/.*" access="ROLE_ADMINISTRATOR" />
   <intercept-url pattern="/extractorapp/.*" access="ROLE_MOD_EXTRACTORAPP" />


### PR DESCRIPTION
After the https://github.com/georchestra/georchestra/pull/1902 merge, the CAS entrypoint for validating tickets changed ; containing a 'login' in the redirect URL, there was an infinite loop while clicking on the login link in the header.

Note: to be merged into docker-master.