### PR TITLE
mapfishapp - remove deprecated HEADER_HEIGHT in js config

### DIFF
--- a/mapfishapp/js/GEOR_custom.js
+++ b/mapfishapp/js/GEOR_custom.js
@@ -11,13 +11,6 @@ Ext.namespace("GEOR");
 GEOR.custom = {
 
     /**
-     * Constant: HEADER_HEIGHT
-     * Integer value representing the header height, as set in the shared maven filters
-     * Defaults to 90
-     */
-    HEADER_HEIGHT: 90,
-
-    /**
      * Constant: DEFAULT_WMC
      * The relative path to the default context.
      *


### PR DESCRIPTION
After https://github.com/georchestra/georchestra/pull/2066