### PR TITLE
Add osm.geopicardie.fr service to the list of default available wmts servers

### DIFF
--- a/mapfishapp/wmts.servers.json
+++ b/mapfishapp/wmts.servers.json
@@ -13,6 +13,10 @@
             "url": "https://tile.geobretagne.fr/gwc02/service/wmts"
         },
         {
+            "name": "GéoPicardie OSM",
+            "url": "https://osm.geopicardie.fr/mapproxy/service"
+        },
+        {
             "name": "IGN GéoPortail",
             "url": "https://wxs.ign.fr/opbnnt8s6esy6680ptjfqmwo/geoportail/wmts"
         }


### PR DESCRIPTION
Note that we need to add the fqdn to `removed-xforwarded-headers.properties` for it to work fine, the remote mapproxy behaves weird.. probably a badly configured reverse proxy on the remote side.

@ndamiens are you fine with that ? @bchartier, an opinion ? That would allow to provide an alternative to the poor overloaded osm.geobretagne.fr, i think @fphg will like it :)