### PR TITLE
security-proxy - remove dependency to configjar

### DIFF
--- a/security-proxy/security-proxy.properties
+++ b/security-proxy/security-proxy.properties
@@ -1,5 +1,5 @@
 # ------   proxy-servlet.xml   ---------
-public.host=${publicUrl}
+public.host=https://georchestra.mydomain.org
 # default timeout : 20min should be enough to handle big extraction (~ 4x10^9 pixels)
 http_client_timeout=1200000
 
@@ -7,13 +7,13 @@ http_client_timeout=1200000
 anonymousRole=ROLE_ANONYMOUS
 proxy.contextPath=/sec
 # url called when user has logged out
-logout-success-url=${publicUrl}/cas/logout?fromgeorchestra
+logout-success-url=https://georchestra.mydomain.org/cas/logout?fromgeorchestra
 # url where the user can login
-casLoginUrl=${publicUrl}/cas/login
+casLoginUrl=https://georchestra.mydomain.org/cas/login
 # url that the security system uses to validate the cas tickets
-casTicketValidation=${publicUrl}/cas
+casTicketValidation=https://georchestra.mydomain.org/cas
 # After going to the cas login cas forwards to this URL where the authorities and permissions are checked
-proxyCallback=${publicUrl}/login/cas
+proxyCallback=https://georchestra.mydomain.org/login/cas
 # list of trusted proxy, all request from listed server will be trusted and will bypass security
 trustedProxy=127.0.0.1, localhost
 # the ldap url


### PR DESCRIPTION
The property files will no more be filtered, so they cannot contain
placeholders (`${...}`).

See https://github.com/georchestra/georchestra/issues/1417.