### PR TITLE
cas - remove dependency to configjar

### DIFF
--- a/cas/cas.properties
+++ b/cas/cas.properties
@@ -1,5 +1,5 @@
-server.name=${publicUrl}
-server.prefix=${publicUrl}/cas
+server.name=https://georchestra.mydomain.org
+server.prefix=https://georchestra.mydomain.org/cas
 instance.name=geOrchestra
 
 # Uncomment to override header height (size in px) or header url in the console


### PR DESCRIPTION
The property files will no more be filtered, so they cannot contain
placeholders (`${...}`).

See https://github.com/georchestra/georchestra/issues/1417.