### PR TITLE
atlas - remove dependency to configjar

### DIFF
--- a/atlas/atlas.properties
+++ b/atlas/atlas.properties
@@ -8,7 +8,7 @@ smtpHost=localhost
 smtpPort=25
 
 # Other
-atlas.baseUrl=${publicUrl}/atlas
+atlas.baseUrl=https://georchestra.mydomain.org/atlas
 atlas.emailFrom=noreply+atlas@georchestra.org
 atlas.emailSubject=[geOrchestra] Your Atlas request
 


### PR DESCRIPTION
The property files will no more be filtered, so they cannot contain
placeholders (${...}).

See https://github.com/georchestra/georchestra/issues/1417.