### PR TITLE
Harmonize headerHeight property name

### DIFF
--- a/default.properties
+++ b/default.properties
@@ -7,6 +7,7 @@ publicUrl=https://georchestra.mydomain.org
 # Name of this geOrchestra instance
 instanceName=geOrchestra
 
-# Configure Header
+# Header height (size in px)
 headerHeight=90
+# Header URL (can be absolute or relative)
 headerUrl=/header/

--- a/geowebcache/geowebcache.properties
+++ b/geowebcache/geowebcache.properties
@@ -3,5 +3,5 @@ contextPath=/geowebcache
 # Name of this instance. Uncomment to override default value
 # instanceName=geOrchestra
 
-header.height=90
-
+# Header height (size in px). Uncomment to override default value
+# headerHeight=90


### PR DESCRIPTION
Also comment by default the property for geowebcache as it is already for the other modules (except mapfishapp).
And add comments in default.properties.

See https://github.com/georchestra/georchestra/pull/2368.