### PR TITLE
"en" default language everywhere

### DIFF
--- a/mapfishapp/js/GEOR_custom.js
+++ b/mapfishapp/js/GEOR_custom.js
@@ -398,7 +398,7 @@ GEOR.custom = {
         country: 'FR',         // France
         //adminCode1: '75',    // Region
         style: 'short',        // verbosity of results
-        lang: 'fr',
+        lang: 'en',
         featureClass: 'P',     // class category: populated places
         maxRows: 20            // maximal number of results
     },


### PR DESCRIPTION
(even if the default results of GEONAMES are for France)