### PR TITLE
console - remove unused properties

### DIFF
--- a/console/console.properties
+++ b/console/console.properties
@@ -63,13 +63,12 @@ ldapUrl=ldap://localhost:389
 baseDN=dc=georchestra,dc=org
 ldapAdminDn=cn=admin,dc=georchestra,dc=org
 ldap.admin.password=secret
-roleUniqueNumberField=ou
+# LDAP organizational units:
 userSearchBaseDN=ou=users
 roleSearchBaseDN=ou=roles
 orgSearchBaseDN=ou=orgs
 pendingUserSearchBaseDN=ou=pendingusers
 pendingOrgSearchBaseDN=ou=pendingorgs
-accountUniqueNumberField=employeeNumber
 
 # PostGreSQL database connection parameters
 psql.url=jdbc:postgresql://localhost:5432/georchestra


### PR DESCRIPTION
`roleUniqueNumberField` and `accountUniqueNumberField` do not seem to be in use by the console code on master