### PR TITLE
Add configuration for connection pool dimensioning

### DIFF
--- a/analytics/analytics.properties
+++ b/analytics/analytics.properties
@@ -7,6 +7,10 @@
 # This variable configures the JDBC URL to the database where the statistics
 # gathered by the OGC-server-statistics module are stored
 dlJdbcUrlOGC=jdbc:postgresql://localhost:5432/georchestra?user=georchestra&password=georchestra
+dataSource.minPoolSize=2
+dataSource.maxPoolSize=2
+dataSource.timeout=2000
+
 
 # Timezone to convert datetime sent by UI to UTC
 # (see Canonical ID on http://joda-time.sourceforge.net/timezones.html for possible values)

--- a/atlas/atlas.properties
+++ b/atlas/atlas.properties
@@ -2,6 +2,9 @@
 psql.url=jdbc:postgresql://localhost:5432/georchestra
 psql.user=georchestra
 psql.pass=georchestra
+dataSource.minPoolSize=1
+dataSource.maxPoolSize=5
+dataSource.timeout=2000
 
 # SMTP configuration
 smtpHost=localhost

--- a/console/console.properties
+++ b/console/console.properties
@@ -78,6 +78,10 @@ pendingOrgSearchBaseDN=ou=pendingorgs
 psql.url=jdbc:postgresql://localhost:5432/georchestra
 psql.user=georchestra
 psql.pass=georchestra
+dataSource.minPoolSize=1
+dataSource.maxPoolSize=10
+dataSource.timeout=2000
+
 
 # SMTP configuration
 smtpHost=localhost

--- a/extractorapp/extractorapp.properties
+++ b/extractorapp/extractorapp.properties
@@ -14,6 +14,9 @@ privileged_admin_pass=gerlsSnFd6SmM
 
 # Link to DB to store extraction statistics in 'extractorapp' schema
 jdbcurl=jdbc:postgresql://localhost:5432/georchestra?user=georchestra&password=georchestra
+dataSource.minPoolSize=1
+dataSource.maxPoolSize=10
+dataSource.timeout=2000
 
 # max extraction size in pixels
 maxCoverageExtractionSize=99999999

--- a/mapfishapp/mapfishapp.properties
+++ b/mapfishapp/mapfishapp.properties
@@ -5,5 +5,9 @@
 # headerUrl=/header/
 
 jdbcUrl=jdbc:postgresql://localhost:5432/georchestra?user=georchestra&password=georchestra
+dataSource.minPoolSize=1
+dataSource.maxPoolSize=10
+dataSource.timeout=2000
+
 
 docTempDir=/tmp

--- a/security-proxy/log4j/log4j.properties
+++ b/security-proxy/log4j/log4j.properties
@@ -25,6 +25,7 @@ log4j.appender.R.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %
 # OGC services statistics
 log4j.appender.OGCSTATISTICS=org.georchestra.ogcservstatistics.log4j.OGCServicesAppender
 log4j.appender.OGCSTATISTICS.activated=true
-log4j.appender.OGCSTATISTICS.jdbcURL=jdbc:postgresql://localhost:5432/georchestra
-log4j.appender.OGCSTATISTICS.databaseUser=georchestra
-log4j.appender.OGCSTATISTICS.databasePassword=georchestra
+#The following properties are deprecated, connection pool configured in security-proxy.properties
+#log4j.appender.OGCSTATISTICS.jdbcURL=jdbc:postgresql://localhost:5432/georchestra
+#log4j.appender.OGCSTATISTICS.databaseUser=georchestra
+#log4j.appender.OGCSTATISTICS.databasePassword=georchestra

--- a/security-proxy/security-proxy.properties
+++ b/security-proxy/security-proxy.properties
@@ -50,3 +50,10 @@ realmName=georchestra
 # The security-proxy will 302 redirect / to the defaultTarget value (/header by default).
 # Change it if your homepage (eg a CMS) is located on /portal/ for instance
 defaultTarget=/header/
+
+# Connection pool settings for the logger appender that inserts OGC request stats on the database
+ogcStats.jdbcURL=jdbc:postgresql://database:5432/georchestra
+ogcStats.databaseUser=georchestra
+ogcStats.databasePassword=georchestra
+ogcStats.minPoolSize=1
+ogcStats.maxPoolSize=5


### PR DESCRIPTION
All apps that connect to Postgres through JDBC now
have a unified way of configuring the DataSource
as a connection pool.

This patch sets the default values for these configurable
properties on each app .properties file.