### PR TITLE
Use the comma-separated list format to configure the excluded users

### DIFF
--- a/analytics/analytics.properties
+++ b/analytics/analytics.properties
@@ -18,7 +18,7 @@ dataSource.maxIdleTime=60
 # (see Canonical ID on http://joda-time.sourceforge.net/timezones.html for possible values)
 localTimezone=Europe/Paris
 
-# List of user to exclude from distinct users statistics (/analytics/ws/distinctUsers)
-# You can add other users to exclude with :
-#excludedUser.uid2=monitoringUser
-excludedUser.uid1=geoserver_privileged_user
+# List of users to exclude from distinct users statistics (/analytics/ws/distinctUsers)
+# You can specify various users to exclude, separating their uid with a comma:
+#excludedUsers=geoserver_privileged_user,monitoringUser
+excludedUsers=geoserver_privileged_user


### PR DESCRIPTION
instead of setting different properties suffixed with a different
number.