### PR TITLE
Use placeholders in properties files to reduce redundancy

### DIFF
--- a/analytics/analytics.properties
+++ b/analytics/analytics.properties
@@ -1,18 +1,18 @@
 # Name of the geOrchestra instance
-# default: geOrchestra, see default.properties
-#instanceName=geOrchestra
+# default: see default.properties - uncomment to override
+#instanceName=
 
 # Language of the interface
-# default: en, see default.properties
-#language=en
+# default: see default.properties - uncomment to override
+#language=
 
 # Header height (in px)
-# default: 90, see default.properties
-#headerHeight=90
+# default: see default.properties - uncomment to override
+#headerHeight=
 
 # Header URL (can be absolute or relative)
-# default: /header/, see default.properties
-#headerUrl=/header/
+# default: see default.properties - uncomment to override
+#headerUrl=
 
 # This variable configures the JDBC URL to the database where the statistics
 # gathered by the OGC-server-statistics module are stored

--- a/atlas/atlas.properties
+++ b/atlas/atlas.properties
@@ -36,16 +36,16 @@
 #smtpPort=25
 
 # URL of the Atlas application
-# default: https://georchestra.mydomain.org/atlas
-#atlas.baseUrl=https://georchestra.mydomain.org/atlas
+# default: ${publicUrl}/atlas
+#atlas.baseUrl=${publicUrl}/atlas
 
 # "From" field in the emails sent by the application
 # default: noreply+atlas@georchestra.org
 #atlas.emailFrom=noreply+atlas@georchestra.org
 
 # "Subject" field in the emails sent by the application
-# default: [geOrchestra] Your Atlas request
-#atlas.emailSubject=[geOrchestra] Your Atlas request
+# default: [${instanceName}] Your Atlas request
+#atlas.emailSubject=[${instanceName}] Your Atlas request
 
 # Directory for the temporary files
 # default: /tmp/atlas

--- a/atlas/atlas.properties
+++ b/atlas/atlas.properties
@@ -36,16 +36,16 @@
 #smtpPort=25
 
 # URL of the Atlas application
-# default: ${publicUrl:https://georchestra.mydomain.org}/atlas
-#atlas.baseUrl=${publicUrl:https://georchestra.mydomain.org}/atlas
+# default: ${publicUrl}/atlas
+#atlas.baseUrl=${publicUrl}/atlas
 
 # "From" field in the emails sent by the application
 # default: noreply+atlas@georchestra.org
 #atlas.emailFrom=noreply+atlas@georchestra.org
 
 # "Subject" field in the emails sent by the application
-# default: [${instanceName:geOrchestra}] Your Atlas request
-#atlas.emailSubject=[${instanceName:geOrchestra}] Your Atlas request
+# default: [${instanceName}] Your Atlas request
+#atlas.emailSubject=[${instanceName}] Your Atlas request
 
 # Directory for the temporary files
 # default: /tmp/atlas

--- a/atlas/atlas.properties
+++ b/atlas/atlas.properties
@@ -36,16 +36,16 @@
 #smtpPort=25
 
 # URL of the Atlas application
-# default: ${publicUrl}/atlas
-#atlas.baseUrl=${publicUrl}/atlas
+# default: ${publicUrl:https://georchestra.mydomain.org}/atlas
+#atlas.baseUrl=${publicUrl:https://georchestra.mydomain.org}/atlas
 
 # "From" field in the emails sent by the application
 # default: noreply+atlas@georchestra.org
 #atlas.emailFrom=noreply+atlas@georchestra.org
 
 # "Subject" field in the emails sent by the application
-# default: [${instanceName}] Your Atlas request
-#atlas.emailSubject=[${instanceName}] Your Atlas request
+# default: [${instanceName:geOrchestra}] Your Atlas request
+#atlas.emailSubject=[${instanceName:geOrchestra}] Your Atlas request
 
 # Directory for the temporary files
 # default: /tmp/atlas

--- a/cas/cas.properties
+++ b/cas/cas.properties
@@ -1,20 +1,26 @@
 # Name of the CAS server
+# This property is required and has no default value. Do not comment
+# This property SHOULD be let unmodified. If you need to modify the URL, see
+# "publicURL" in default.properties.
 server.name=${publicUrl}
 
 # Prefix of the CAS server
+# This property is required and has no default value. Do not comment
+# This property SHOULD be let unmodified. If you need to modify the URL, see
+# "publicURL" in default.properties.
 server.prefix=${server.name}/cas
 
 # Name of the geOrchestra instance
-# default: geOrchestra, see default.properties
-#instanceName=geOrchestra
+# default: see default.properties - uncomment to override
+#instanceName=
 
 # Header height (in px)
-# default: 90, see default.properties
-#headerHeight=90
+# default: see default.properties - uncomment to override
+#headerHeight=
 
 # Header URL (can be absolute or relative)
-# default: /header/, see default.properties
-#headerUrl=/header/
+# default: see default.properties - uncomment to override
+#headerUrl=
 
 # IP address or CIDR subnet allowed to access the /status URI of CAS that
 # exposes health check information

--- a/cas/cas.properties
+++ b/cas/cas.properties
@@ -1,8 +1,8 @@
 # Name of the CAS server
-server.name=https://georchestra.mydomain.org
+server.name=${publicUrl}
 
 # Prefix of the CAS server
-server.prefix=https://georchestra.mydomain.org/cas
+server.prefix=${server.name}/cas
 
 # Name of the geOrchestra instance
 # default: geOrchestra, see default.properties

--- a/cas/cas.properties
+++ b/cas/cas.properties
@@ -2,13 +2,13 @@
 # This property is required and has no default value. Do not comment
 # This property SHOULD be let unmodified. If you need to modify the URL, see
 # "publicURL" in default.properties.
-server.name=${publicUrl:https://georchestra.mydomain.org}
+server.name=${publicUrl}
 
 # Prefix of the CAS server
 # This property is required and has no default value. Do not comment
 # This property SHOULD be let unmodified. If you need to modify the URL, see
 # "publicURL" in default.properties.
-server.prefix=${publicUrl:https://georchestra.mydomain.org}/cas
+server.prefix=${publicUrl}/cas
 
 # Name of the geOrchestra instance
 # default: see default.properties - uncomment to override
@@ -43,8 +43,8 @@ server.prefix=${publicUrl:https://georchestra.mydomain.org}/cas
 # Unique CAS node name
 # host.name is used to generate unique Service Ticket IDs and SAMLArtifacts.  This is usually set to the specific
 # hostname of the machine running the CAS node, but it could be any label so long as it is unique in the cluster.
-# default: ${domainName:georchestra.mydomain.org}
-#host.name=${domainName:georchestra.mydomain.org}
+# default: ${domainName}
+#host.name=${domainName}
 
 # LDAP server URL
 # default: ldap://127.0.1.1:389

--- a/cas/cas.properties
+++ b/cas/cas.properties
@@ -37,8 +37,8 @@ server.prefix=${server.name}/cas
 # Unique CAS node name
 # host.name is used to generate unique Service Ticket IDs and SAMLArtifacts.  This is usually set to the specific
 # hostname of the machine running the CAS node, but it could be any label so long as it is unique in the cluster.
-# default: georchestra.mydomain.org
-#host.name=georchestra.mydomain.org
+# default: ${domainName}
+#host.name=${domainName}
 
 # LDAP server URL
 # default: ldap://127.0.1.1:389

--- a/cas/cas.properties
+++ b/cas/cas.properties
@@ -43,8 +43,8 @@ server.prefix=${server.name}/cas
 # Unique CAS node name
 # host.name is used to generate unique Service Ticket IDs and SAMLArtifacts.  This is usually set to the specific
 # hostname of the machine running the CAS node, but it could be any label so long as it is unique in the cluster.
-# default: ${domainName}
-#host.name=${domainName}
+# default: ${domainName:georchestra.mydomain.org}
+#host.name=${domainName:georchestra.mydomain.org}
 
 # LDAP server URL
 # default: ldap://127.0.1.1:389

--- a/cas/cas.properties
+++ b/cas/cas.properties
@@ -2,13 +2,13 @@
 # This property is required and has no default value. Do not comment
 # This property SHOULD be let unmodified. If you need to modify the URL, see
 # "publicURL" in default.properties.
-server.name=${publicUrl}
+server.name=${publicUrl:https://georchestra.mydomain.org}
 
 # Prefix of the CAS server
 # This property is required and has no default value. Do not comment
 # This property SHOULD be let unmodified. If you need to modify the URL, see
 # "publicURL" in default.properties.
-server.prefix=${server.name}/cas
+server.prefix=${publicUrl:https://georchestra.mydomain.org}/cas
 
 # Name of the geOrchestra instance
 # default: see default.properties - uncomment to override

--- a/console/console.properties
+++ b/console/console.properties
@@ -3,16 +3,16 @@
 # General purposes properties
 
 # Name of the geOrchestra instance
-# default: geOrchestra
-#instanceName=geOrchestra
+# default: see default.properties - uncomment to override
+#instanceName=
 
 # Header height (in px)
-# default: 90
-#headerHeight=90
+# default: see default.properties - uncomment to override
+#headerHeight=
 
 # Header URL (can be absolute or relative)
-# default: /header/
-#headerUrl=/header/
+# default: see default.properties - uncomment to override
+#headerUrl=
 
 # Public context path for the application
 # default: /console

--- a/console/console.properties
+++ b/console/console.properties
@@ -204,28 +204,28 @@
 #from=georchestra+testadmin@georchestra.mydomain.org
 
 # Subject of email when your account has been created
-# default: [geOrchestra] Your account has been created
-#subject.account.created=[geOrchestra] Your account has been created
+# default: [${instanceName}] Your account has been created
+#subject.account.created=[${instanceName}] Your account has been created
 
 # Subject of email when your account creation is waiting for validation
-# default: [geOrchestra] Your new account is waiting for validation
-#subject.account.in.process=[geOrchestra] Your new account is waiting for validation
+# default: [${instanceName}] Your new account is waiting for validation
+#subject.account.in.process=[${instanceName}] Your new account is waiting for validation
 
 # Subject of email for moderator at account creation
-# default: [geOrchestra] New account waiting for validation
-#subject.requires.moderation=[geOrchestra] New account waiting for validation
+# default: [${instanceName}] New account waiting for validation
+#subject.requires.moderation=[${instanceName}] New account waiting for validation
 
 # Subject of email for password change
-# default: [geOrchestra] Update your password
-#subject.change.password=[geOrchestra] Update your password
+# default: [${instanceName}] Update your password
+#subject.change.password=[${instanceName}] Update your password
 
 # Subject of email for login change
-# default: [geOrchestra] New login for your account
-#subject.account.uid.renamed=[geOrchestra] New login for your account
+# default: [${instanceName}] New login for your account
+#subject.account.uid.renamed=[${instanceName}] New login for your account
 
 # Subject of email when a new account has been created
-# default: [geOrchestra] New account created
-#subject.new.account.notification=[geOrchestra] New account created
+# default: [${instanceName}] New account created
+#subject.new.account.notification=[${instanceName}] New account created
 
 # Encoding of the email templates
 # This "é" char should display nicely in a ISO 8859-1 configured editor

--- a/console/console.properties
+++ b/console/console.properties
@@ -204,28 +204,28 @@
 #from=georchestra+testadmin@georchestra.mydomain.org
 
 # Subject of email when your account has been created
-# default: [${instanceName}] Your account has been created
-#subject.account.created=[${instanceName}] Your account has been created
+# default: [${instanceName:geOrchestra}] Your account has been created
+#subject.account.created=[${instanceName:geOrchestra}] Your account has been created
 
 # Subject of email when your account creation is waiting for validation
-# default: [${instanceName}] Your new account is waiting for validation
-#subject.account.in.process=[${instanceName}] Your new account is waiting for validation
+# default: [${instanceName:geOrchestra}] Your new account is waiting for validation
+#subject.account.in.process=[${instanceName:geOrchestra}] Your new account is waiting for validation
 
 # Subject of email for moderator at account creation
-# default: [${instanceName}] New account waiting for validation
-#subject.requires.moderation=[${instanceName}] New account waiting for validation
+# default: [${instanceName:geOrchestra}] New account waiting for validation
+#subject.requires.moderation=[${instanceName:geOrchestra}] New account waiting for validation
 
 # Subject of email for password change
-# default: [${instanceName}] Update your password
-#subject.change.password=[${instanceName}] Update your password
+# default: [${instanceName:geOrchestra}] Update your password
+#subject.change.password=[${instanceName:geOrchestra}] Update your password
 
 # Subject of email for login change
-# default: [${instanceName}] New login for your account
-#subject.account.uid.renamed=[${instanceName}] New login for your account
+# default: [${instanceName:geOrchestra}] New login for your account
+#subject.account.uid.renamed=[${instanceName:geOrchestra}] New login for your account
 
 # Subject of email when a new account has been created
-# default: [${instanceName}] New account created
-#subject.new.account.notification=[${instanceName}] New account created
+# default: [${instanceName:geOrchestra}] New account created
+#subject.new.account.notification=[${instanceName:geOrchestra}] New account created
 
 # Encoding of the email templates
 # This "é" char should display nicely in a ISO 8859-1 configured editor

--- a/console/console.properties
+++ b/console/console.properties
@@ -204,28 +204,28 @@
 #from=georchestra+testadmin@georchestra.mydomain.org
 
 # Subject of email when your account has been created
-# default: [${instanceName:geOrchestra}] Your account has been created
-#subject.account.created=[${instanceName:geOrchestra}] Your account has been created
+# default: [${instanceName}] Your account has been created
+#subject.account.created=[${instanceName}] Your account has been created
 
 # Subject of email when your account creation is waiting for validation
-# default: [${instanceName:geOrchestra}] Your new account is waiting for validation
-#subject.account.in.process=[${instanceName:geOrchestra}] Your new account is waiting for validation
+# default: [${instanceName}] Your new account is waiting for validation
+#subject.account.in.process=[${instanceName}] Your new account is waiting for validation
 
 # Subject of email for moderator at account creation
-# default: [${instanceName:geOrchestra}] New account waiting for validation
-#subject.requires.moderation=[${instanceName:geOrchestra}] New account waiting for validation
+# default: [${instanceName}] New account waiting for validation
+#subject.requires.moderation=[${instanceName}] New account waiting for validation
 
 # Subject of email for password change
-# default: [${instanceName:geOrchestra}] Update your password
-#subject.change.password=[${instanceName:geOrchestra}] Update your password
+# default: [${instanceName}] Update your password
+#subject.change.password=[${instanceName}] Update your password
 
 # Subject of email for login change
-# default: [${instanceName:geOrchestra}] New login for your account
-#subject.account.uid.renamed=[${instanceName:geOrchestra}] New login for your account
+# default: [${instanceName}] New login for your account
+#subject.account.uid.renamed=[${instanceName}] New login for your account
 
 # Subject of email when a new account has been created
-# default: [${instanceName:geOrchestra}] New account created
-#subject.new.account.notification=[${instanceName:geOrchestra}] New account created
+# default: [${instanceName}] New account created
+#subject.new.account.notification=[${instanceName}] New account created
 
 # Encoding of the email templates
 # This "é" char should display nicely in a ISO 8859-1 configured editor

--- a/console/templates/account-uid-renamed.txt
+++ b/console/templates/account-uid-renamed.txt
@@ -1,7 +1,7 @@
 Dear {name}, 
 
 This message is intended to let you know that your identifier on the
-geOrchestra platform has been modified.
+{instanceName} platform has been modified.
 
 Your new login is now: {uid}
 

--- a/default.properties
+++ b/default.properties
@@ -21,7 +21,7 @@ domainName=georchestra.mydomain.org
 
 # Public URL of this geOrchestra instance
 # URL must not include the trailing slash
-publicUrl=${scheme}://${domain}
+publicUrl=${scheme}://${domainName}
 
 # Name of this geOrchestra instance
 instanceName=geOrchestra

--- a/default.properties
+++ b/default.properties
@@ -36,5 +36,5 @@ headerHeight=90
 
 # Header URL (can be absolute or relative)
 # If different from default value "/header/", adapt
-# security-proxy/targetsmapping.properties accordingly
+# security-proxy/targets-mapping.properties accordingly
 headerUrl=/header/

--- a/default.properties
+++ b/default.properties
@@ -2,6 +2,16 @@
 
 # Public URL of this geOrchestra instance
 # URL must not include the trailing slash
+# Once modified, adapt the following files accordingly:
+# - mapfishapp/wfs.servers.json
+# - mapfishapp/wms.servers.json
+# - mapfishapp/wmts.servers.json
+# - mapfishapp/credentials.properties
+# - mapfishapp/print/config.yaml
+# - mapfishapp/js/GEOR_custom.js
+# - cas/cas.properties
+# - ...
+# or replace all the strings with `sed` (see README.md)
 publicUrl=https://georchestra.mydomain.org
 
 # Name of this geOrchestra instance
@@ -11,7 +21,11 @@ instanceName=geOrchestra
 language=en
 
 # Header height (size in px)
+# If different from default value "90", adapt analytics/js/GEOR_custom.js
+# accordingly
 headerHeight=90
 
 # Header URL (can be absolute or relative)
+# If different from default value "/header/", adapt
+# security-proxy/targetsmapping.properties accordingly
 headerUrl=/header/

--- a/default.properties
+++ b/default.properties
@@ -1,6 +1,11 @@
 # This file holds some property shared across all geOrchestra webapps
 
-# Public URL of this geOrchestra instance
+# Scheme of the geOrchestra instance
+# URL must not include the trailing slash
+# Should be https
+scheme=https
+
+# Domain name of the geOrchestra instance
 # URL must not include the trailing slash
 # Once modified, adapt the following files accordingly:
 # - mapfishapp/wfs.servers.json
@@ -12,7 +17,11 @@
 # - cas/cas.properties
 # - ...
 # or replace all the strings with `sed` (see README.md)
-publicUrl=https://georchestra.mydomain.org
+domainName=georchestra.mydomain.org
+
+# Public URL of this geOrchestra instance
+# URL must not include the trailing slash
+publicUrl=${scheme}://${domain}
 
 # Name of this geOrchestra instance
 instanceName=geOrchestra

--- a/default.properties
+++ b/default.properties
@@ -1,4 +1,7 @@
 # This file holds some property shared across all geOrchestra webapps
+# All properties in this file MUST be present. Do not comment any of them, they
+# do not have a default value. Adapt them according to the needs of your
+# instance.
 
 # Scheme of the geOrchestra instance
 # URL must not include the trailing slash
@@ -21,6 +24,8 @@ domainName=georchestra.mydomain.org
 
 # Public URL of this geOrchestra instance
 # URL must not include the trailing slash
+# This property MUST be let unmodified. If you need to modify the scheme or the
+# domain name, refer to the "scheme" and "domainName" properties.
 publicUrl=${scheme}://${domainName}
 
 # Name of this geOrchestra instance

--- a/extractorapp/extractorapp.properties
+++ b/extractorapp/extractorapp.properties
@@ -1,6 +1,6 @@
 # URL of the geOrchestra instance
-# default: https://georchestra.mydomain.org, see default.properties
-#publicUrl=https://georchestra.mydomain.org
+# default: publicUrl=${scheme}://${domainName}, see default.properties
+#publicUrl=publicUrl=${scheme}://${domainName} 
 
 # Language of the interface
 # default: en, see default.properties

--- a/extractorapp/extractorapp.properties
+++ b/extractorapp/extractorapp.properties
@@ -85,8 +85,8 @@
 #extractionFolderPrefix=extraction-
 
 # Subject of the extraction emails
-# default: [${instanceName}] Your extraction request
-#emailsubject=[${instanceName}] Your extraction request
+# default: [${instanceName:geOrchestra}] Your extraction request
+#emailsubject=[${instanceName:geOrchestra}] Your extraction request
 
 
 # Minimum number of threads for extractionManager bean

--- a/extractorapp/extractorapp.properties
+++ b/extractorapp/extractorapp.properties
@@ -1,10 +1,10 @@
 # URL of the geOrchestra instance
-# default: publicUrl=${scheme}://${domainName}, see default.properties
-#publicUrl=publicUrl=${scheme}://${domainName} 
+# default: see default.properties - uncomment to override
+#publicUrl=
 
 # Language of the interface
-# default: en, see default.properties
-#language=en
+# default: see default.properties - uncomment to override
+#language=
 
 
 # Email properties

--- a/extractorapp/extractorapp.properties
+++ b/extractorapp/extractorapp.properties
@@ -85,8 +85,8 @@
 #extractionFolderPrefix=extraction-
 
 # Subject of the extraction emails
-# default: [geOrchestra] Your extraction request
-#emailsubject=[geOrchestra] Your extraction request
+# default: [${instanceName}] Your extraction request
+#emailsubject=[${instanceName}] Your extraction request
 
 
 # Minimum number of threads for extractionManager bean

--- a/extractorapp/extractorapp.properties
+++ b/extractorapp/extractorapp.properties
@@ -85,8 +85,8 @@
 #extractionFolderPrefix=extraction-
 
 # Subject of the extraction emails
-# default: [${instanceName:geOrchestra}] Your extraction request
-#emailsubject=[${instanceName:geOrchestra}] Your extraction request
+# default: [${instanceName}] Your extraction request
+#emailsubject=[${instanceName}] Your extraction request
 
 
 # Minimum number of threads for extractionManager bean

--- a/geowebcache/geowebcache.properties
+++ b/geowebcache/geowebcache.properties
@@ -1,10 +1,10 @@
 # Name of the geOrchestra instance
-# default: geOrchestra, see default.properties
-#instanceName=geOrchestra
+# default: see default.properties - uncomment to override
+#instanceName=
 
 # Header height (in px)
-# default: 90, see default.properties
-#headerHeight=90
+# default: see default.properties - uncomment to override
+#headerHeight=
 
 # Context path of the application
 # default: /geowebcache

--- a/header/header.properties
+++ b/header/header.properties
@@ -1,6 +1,6 @@
 # Language of the interface
-# default: en, see default.properties
-#language=en
+# default: see default.properties - uncomment to override
+#language=
 
 # Context path of the console application
 # default: /console

--- a/mapfishapp/mapfishapp.properties
+++ b/mapfishapp/mapfishapp.properties
@@ -1,18 +1,18 @@
 # Name of the geOrchestra instance
-# default: geOrchestra, see default.properties
-#instanceName=geOrchestra
+# default: see default.properties - uncomment to override
+#instanceName=
 
 # Language of the interface
-# default: en, see default.properties
-#language=en
+# default: see default.properties - uncomment to override
+#language=
 
 # Header height (in px)
-# default: 90, see default.properties
-#headerHeight=90
+# default: see default.properties - uncomment to override
+#headerHeight=
 
 # Header URL (can be absolute or relative)
-# default: /header/, see default.properties
-#headerUrl=/header/
+# default: see default.properties - uncomment to override
+#headerUrl=
 
 
 # PostGreSQL server URL

--- a/security-proxy/security-proxy.properties
+++ b/security-proxy/security-proxy.properties
@@ -16,20 +16,20 @@
 #proxy.contextPath=/sec
 
 # URL called when user has logged out
-# default: ${publicUrl:https://georchestra.mydomain.org}/cas/logout?fromgeorchestra
-#logout-success-url=${publicUrl:https://georchestra.mydomain.org}/cas/logout?fromgeorchestra
+# default: ${publicUrl}/cas/logout?fromgeorchestra
+#logout-success-url=${publicUrl}/cas/logout?fromgeorchestra
 
 # URL where the user can login
-# default: ${publicUrl:https://georchestra.mydomain.org}/cas/login
-#casLoginUrl=${publicUrl:https://georchestra.mydomain.org}/cas/login
+# default: ${publicUrl}/cas/login
+#casLoginUrl=${publicUrl}/cas/login
 
 # URL that the security system uses to validate the cas tickets
-# default: ${publicUrl:https://georchestra.mydomain.org}/cas
-#casTicketValidation=${publicUrl:https://georchestra.mydomain.org}/cas
+# default: ${publicUrl}/cas
+#casTicketValidation=${publicUrl}/cas
 
 # After going to the cas login cas forwards to this URL where the authorities and permissions are checked
-# default: ${publicUrl:https://georchestra.mydomain.org}/login/cas
-#proxyCallback=${publicUrl:https://georchestra.mydomain.org}/login/cas
+# default: ${publicUrl}/login/cas
+#proxyCallback=${publicUrl}/login/cas
 
 # List of trusted proxies, all requests from listed server will be trusted and
 # will bypass security
@@ -97,8 +97,8 @@
 
 # The security-proxy will 302 redirect / to the defaultTarget value (/header by default).
 # Change it if your homepage (eg a CMS) is located on /portal/ for instance
-# default: ${headerUrl:/header/}
-#defaultTarget=${headerUrl:/header/}
+# default: ${headerUrl}
+#defaultTarget=${headerUrl}
 
 
 # Connection pool settings for the logger appender that inserts OGC request stats on the database

--- a/security-proxy/security-proxy.properties
+++ b/security-proxy/security-proxy.properties
@@ -16,20 +16,20 @@
 #proxy.contextPath=/sec
 
 # URL called when user has logged out
-# default: ${publicUrl}/cas/logout?fromgeorchestra
-#logout-success-url=${publicUrl}/cas/logout?fromgeorchestra
+# default: ${publicUrl:https://georchestra.mydomain.org}/cas/logout?fromgeorchestra
+#logout-success-url=${publicUrl:https://georchestra.mydomain.org}/cas/logout?fromgeorchestra
 
 # URL where the user can login
-# default: ${publicUrl}/cas/login
-#casLoginUrl=${publicUrl}/cas/login
+# default: ${publicUrl:https://georchestra.mydomain.org}/cas/login
+#casLoginUrl=${publicUrl:https://georchestra.mydomain.org}/cas/login
 
 # URL that the security system uses to validate the cas tickets
-# default: ${publicUrl}/cas
-#casTicketValidation=${publicUrl}/cas
+# default: ${publicUrl:https://georchestra.mydomain.org}/cas
+#casTicketValidation=${publicUrl:https://georchestra.mydomain.org}/cas
 
 # After going to the cas login cas forwards to this URL where the authorities and permissions are checked
-# default: ${publicUrl}/login/cas
-#proxyCallback=${publicUrl}/login/cas
+# default: ${publicUrl:https://georchestra.mydomain.org}/login/cas
+#proxyCallback=${publicUrl:https://georchestra.mydomain.org}/login/cas
 
 # List of trusted proxies, all requests from listed server will be trusted and
 # will bypass security

--- a/security-proxy/security-proxy.properties
+++ b/security-proxy/security-proxy.properties
@@ -97,8 +97,8 @@
 
 # The security-proxy will 302 redirect / to the defaultTarget value (/header by default).
 # Change it if your homepage (eg a CMS) is located on /portal/ for instance
-# default: ${headerUrl}
-#defaultTarget=${headerUrl}
+# default: ${headerUrl:/header/}
+#defaultTarget=${headerUrl:/header/}
 
 
 # Connection pool settings for the logger appender that inserts OGC request stats on the database

--- a/security-proxy/security-proxy.properties
+++ b/security-proxy/security-proxy.properties
@@ -16,20 +16,20 @@
 #proxy.contextPath=/sec
 
 # URL called when user has logged out
-# default: https://georchestra.mydomain.org/cas/logout?fromgeorchestra
-#logout-success-url=https://georchestra.mydomain.org/cas/logout?fromgeorchestra
+# default: ${publicUrl}/cas/logout?fromgeorchestra
+#logout-success-url=${publicUrl}/cas/logout?fromgeorchestra
 
 # URL where the user can login
-# default: https://georchestra.mydomain.org/cas/login
-#casLoginUrl=https://georchestra.mydomain.org/cas/login
+# default: ${publicUrl}/cas/login
+#casLoginUrl=${publicUrl}/cas/login
 
 # URL that the security system uses to validate the cas tickets
-# default: https://georchestra.mydomain.org/cas
-#casTicketValidation=https://georchestra.mydomain.org/cas
+# default: ${publicUrl}/cas
+#casTicketValidation=${publicUrl}/cas
 
 # After going to the cas login cas forwards to this URL where the authorities and permissions are checked
-# default: https://georchestra.mydomain.org/login/cas
-#proxyCallback=https://georchestra.mydomain.org/login/cas
+# default: ${publicUrl}/login/cas
+#proxyCallback=${publicUrl}/login/cas
 
 # List of trusted proxies, all requests from listed server will be trusted and
 # will bypass security
@@ -95,10 +95,10 @@
 # default: georchestra
 #realmName=georchestra
 
-# The security-proxy will 302 redirect / to the defaultTarget value.
+# The security-proxy will 302 redirect / to the defaultTarget value (/header by default).
 # Change it if your homepage (eg a CMS) is located on /portal/ for instance
-# default: /header/
-#defaultTarget=/header/
+# default: ${headerUrl}
+#defaultTarget=${headerUrl}
 
 
 # Connection pool settings for the logger appender that inserts OGC request stats on the database


### PR DESCRIPTION
The properties from the default.properties file are used inside the
applications properties files. In geOrchestra the default.properties
file is always loaded before the application properties files, so the
default values are available to these as placeholders.