### PR TITLE
Comment (nearly) all properties in properties files

### DIFF
--- a/analytics/analytics.properties
+++ b/analytics/analytics.properties
@@ -1,22 +1,45 @@
-# Uncomment to override default values (see default.properties)
-# instanceName=geOrchestra
-# language=en
-# headerHeight=90
-# headerUrl=/header/
+# Name of the geOrchestra instance
+# default: geOrchestra, see default.properties
+#instanceName=geOrchestra
+
+# Language of the interface
+# default: en, see default.properties
+#language=en
+
+# Header height (in px)
+# default: 90, see default.properties
+#headerHeight=90
+
+# Header URL (can be absolute or relative)
+# default: /header/, see default.properties
+#headerUrl=/header/
 
 # This variable configures the JDBC URL to the database where the statistics
 # gathered by the OGC-server-statistics module are stored
-dlJdbcUrlOGC=jdbc:postgresql://localhost:5432/georchestra?user=georchestra&password=georchestra
-dataSource.minPoolSize=2
-dataSource.maxPoolSize=2
-dataSource.timeout=2000
-#max time unused connections are kept idle in the pool. Unit is seconds for c3p0.
-dataSource.maxIdleTime=60
+# default: jdbc:postgresql://localhost:5432/georchestra?user=georchestra&password=georchestra
+#dlJdbcUrlOGC=jdbc:postgresql://localhost:5432/georchestra?user=georchestra&password=georchestra
 
+# Minimum number of Connections a pool will maintain at any given time.
+# default: 2
+#dataSource.minPoolSize=2
+
+# Maximum number of Connections a pool will maintain at any given time.
+# default: 2
+#dataSource.maxPoolSize=2
+
+# The number of milliseconds a client will wait for a Connection to be
+# checked-in or acquired when the pool is exhausted.
+# default: 2000
+#dataSource.timeout=2000
+
+# Max time unused connections are kept idle in the pool. Unit is seconds for c3p0.
+# default: 60
+#dataSource.maxIdleTime=60
 
 # Timezone to convert datetime sent by UI to UTC
 # (see Canonical ID on http://joda-time.sourceforge.net/timezones.html for possible values)
-localTimezone=Europe/Paris
+# default: Europe/Paris
+#localTimezone=Europe/Paris
 
 # List of user to exclude from distinct users statistics (/analytics/ws/distinctUsers)
 # You can add other users to exclude with :

--- a/atlas/atlas.properties
+++ b/atlas/atlas.properties
@@ -1,20 +1,52 @@
-# PostGreSQL
-psql.url=jdbc:postgresql://localhost:5432/georchestra
-psql.user=georchestra
-psql.pass=georchestra
-dataSource.minPoolSize=1
-dataSource.maxPoolSize=5
-dataSource.timeout=2000
-#max time unused connections are kept idle in the pool. Unit is seconds for c3p0.
-dataSource.maxIdleTime=60
+# PostGreSQL server URL
+# default: jdbc:postgresql://localhost:5432/georchestra
+#psql.url=jdbc:postgresql://localhost:5432/georchestra
 
-# SMTP configuration
-smtpHost=localhost
-smtpPort=25
+# PostGreSQL user
+# default: georchestra
+#psql.user=georchestra
 
-# Other
-atlas.baseUrl=https://georchestra.mydomain.org/atlas
-atlas.emailFrom=noreply+atlas@georchestra.org
-atlas.emailSubject=[geOrchestra] Your Atlas request
+# PostGreSQL password
+# default: georchestra
+#psql.pass=georchestra
 
-atlas.temporaryDirectory=/tmp/atlas
+# Minimum number of Connections a pool will maintain at any given time.
+# default: 1
+#dataSource.minPoolSize=1
+
+# Maximum number of Connections a pool will maintain at any given time.
+# default: 5
+#dataSource.maxPoolSize=5
+
+# The number of milliseconds a client will wait for a Connection to be
+# checked-in or acquired when the pool is exhausted.
+# default: 2000
+#dataSource.timeout=2000
+
+# Max time unused connections are kept idle in the pool. Unit is seconds for c3p0.
+# default: 60
+#dataSource.maxIdleTime=60
+
+# SMTP server domain name
+# default: localhost
+#smtpHost=localhost
+
+# SMTP server domain name
+# default: 25
+#smtpPort=25
+
+# URL of the Atlas application
+# default: https://georchestra.mydomain.org/atlas
+#atlas.baseUrl=https://georchestra.mydomain.org/atlas
+
+# "From" field in the emails sent by the application
+# default: noreply+atlas@georchestra.org
+#atlas.emailFrom=noreply+atlas@georchestra.org
+
+# "Subject" field in the emails sent by the application
+# default: [geOrchestra] Your Atlas request
+#atlas.emailSubject=[geOrchestra] Your Atlas request
+
+# Directory for the temporary files
+# default: /tmp/atlas
+#atlas.temporaryDirectory=/tmp/atlas

--- a/cas/cas.properties
+++ b/cas/cas.properties
@@ -1,45 +1,104 @@
+# Name of the CAS server
 server.name=https://georchestra.mydomain.org
+
+# Prefix of the CAS server
 server.prefix=https://georchestra.mydomain.org/cas
 
-# Name of this instance. Uncomment to override default value
-# instanceName=geOrchestra
+# Name of the geOrchestra instance
+# default: geOrchestra, see default.properties
+#instanceName=geOrchestra
 
-# Uncomment to override header height (size in px) or header url in the console
-# defaults to values defined in ../default.properties
-# headerHeight=90
-# headerUrl=/header/
+# Header height (in px)
+# default: 90, see default.properties
+#headerHeight=90
 
-# IP address or CIDR subnet allowed to access the /status URI of CAS that exposes health check information
-cas.securityContext.status.allowedSubnet=127.0.0.1
+# Header URL (can be absolute or relative)
+# default: /header/, see default.properties
+#headerUrl=/header/
 
-console.contextpath=/console
+# IP address or CIDR subnet allowed to access the /status URI of CAS that
+# exposes health check information
+# default: 127.0.0.1
+#cas.securityContext.status.allowedSubnet=127.0.0.1
 
-cas.themeResolver.defaultThemeName=cas-theme-default
-cas.viewResolver.basename=default_views
+# Context path of the console application
+# default: /console
+#console.contextpath=/console
 
-##
+# CAS theme name
+# default: cas-theme-default
+#cas.themeResolver.defaultThemeName=cas-theme-default
+
+# CAS default basename for ResourceBundleViewResolver
+# see https://github.com/georchestra/georchestra/blob/18.12/cas-server-webapp/src/main/resources/default_views.properties
+# default: default_views
+#cas.viewResolver.basename=default_views
+
 # Unique CAS node name
 # host.name is used to generate unique Service Ticket IDs and SAMLArtifacts.  This is usually set to the specific
 # hostname of the machine running the CAS node, but it could be any label so long as it is unique in the cluster.
-host.name=georchestra.mydomain.org
+# default: georchestra.mydomain.org
+#host.name=georchestra.mydomain.org
 
-ldap.url=ldap://127.0.1.1:389
-ldap.authn.roleSearchBaseDn=ou=roles,dc=georchestra,dc=org
-ldap.authn.userSearchBaseDn=ou=users,dc=georchestra,dc=org
-ldap.authn.searchFilter=(uid={user})
-ldap.admin.username=cn=admin,dc=georchestra,dc=org
-ldap.admin.password=secret
-ldap.authn.roleSearchFilter=(member=uid={1},ou=users,dc=georchestra,dc=org)
-ldap.authn.roleRoleAttribute=cn
+# LDAP server URL
+# default: ldap://127.0.1.1:389
+#ldap.url=ldap://127.0.1.1:389
+
+# Username to connect to the LDAP server
+# default: cn=admin,dc=georchestra,dc=org
+#ldap.admin.username=cn=admin,dc=georchestra,dc=org
+
+# Password to connect to the LDAP server
+# default: secret
+#ldap.admin.password=secret
+
+# DN of the users in LDAP
+# default: ou=users,dc=georchestra,dc=org
+#ldap.authn.userSearchBaseDn=ou=users,dc=georchestra,dc=org
+
+# Filter to search users in LDAP
+# default: (uid={user})
+#ldap.authn.searchFilter=(uid={user})
+
+# DN of the roles in LDAP
+# default: ou=roles,dc=georchestra,dc=org
+#ldap.authn.roleSearchBaseDn=ou=roles,dc=georchestra,dc=org
+
+# Filter to search roles in LDAP
+# default: (member=uid={1},ou=users,dc=georchestra,dc=org)
+#ldap.authn.roleSearchFilter=(member=uid={1},ou=users,dc=georchestra,dc=org)
+
+# LDAP attribute that characterizes a role
+# default: cn
+#ldap.authn.roleRoleAttribute=cn
 
 # See http://www.ldaptive.org/ for information about ldap parameters
-ldap.connectTimeout=30000
-ldap.useStartTLS=false
-ldap.pool.minSize=3
-ldap.pool.maxSize=10
-ldap.pool.validateOnCheckout=false
-ldap.pool.validatePeriodically=false
-ldap.pool.validatePeriod=1800
-ldap.pool.prunePeriod=300
-ldap.pool.idleTime=600
-ldap.pool.blockWaitTime=0
+# default: 30000
+#ldap.connectTimeout=30000
+
+# default: false
+#ldap.useStartTLS=false
+
+# default: 3
+#ldap.pool.minSize=3
+
+# default: 10
+#ldap.pool.maxSize=10
+
+# default: false
+#ldap.pool.validateOnCheckout=false
+
+# default: false
+#ldap.pool.validatePeriodically=false
+
+# default: 1800
+#ldap.pool.validatePeriod=1800
+
+# default: 300
+#ldap.pool.prunePeriod=300
+
+# default: 600
+#ldap.pool.idleTime=600
+
+# default: 0
+#ldap.pool.blockWaitTime=0

--- a/console/console.properties
+++ b/console/console.properties
@@ -2,16 +2,25 @@
 
 # General purposes properties
 
-# Name of this instance. Uncomment to override default value
-# instanceName=geOrchestra
+# Name of the geOrchestra instance
+# default: geOrchestra
+#instanceName=geOrchestra
 
-publicContextPath=/console
-protectedUsersList=geoserver_privileged_user
+# Header height (in px)
+# default: 90
+#headerHeight=90
 
-# Uncomment to override header height (size in px) or header url in the console
-# defaults to values defined in ../default.properties
-# headerHeight=90
-# headerUrl=/header/
+# Header URL (can be absolute or relative)
+# default: /header/
+#headerUrl=/header/
+
+# Public context path for the application
+# default: /console
+#publicContextPath=/console
+
+# List of users protected against modification and deletion
+# default: geoserver_privileged_user
+#protectedUsersList=geoserver_privileged_user
 
 # Account moderation
 # If moderatedSignup is true, each time a new user requests an account:
@@ -22,89 +31,215 @@ protectedUsersList=geoserver_privileged_user
 # Otherwise, the user is immediately considered as registered,
 # and is stored inside the "ou=user" LDAP organizational unit. An email
 # is also sent to SUPERUSER user and delegated admins if any.
+# default: true
+#moderatedSignup=true
 
-moderatedSignup=true
-moderatorEmail=georchestra+testadmin@georchestra.mydomain.org
+# Deprecated
+# default: georchestra+testadmin@georchestra.mydomain.org
+#moderatorEmail=georchestra+testadmin@georchestra.mydomain.org
 
 # Prevent the user from choosing its own username
 # if set to true, username will be 'first letter of firstname+lastname'
-readonlyUid=false
+# default: false
+#readonlyUid=false
 
 # Delay in days before the "I lost my password" token expires
-delayInDays=1
+# default: 1
+#delayInDays=1
 
-# Possible values for org creation form : "orgAddress" and "orgType"
-requiredFields=firstName,surname,org,orgType
+# Fields that MUST be filled in forms
+# Possible values for org creation form: "orgAddress" and "orgType"
+# default: firstName,surname,org,orgType
+#requiredFields=firstName,surname,org,orgType
 
 # Org type values is used to populate the drop down list from /console/account/new
-orgTypeValues=Association,Company,NGO,Individual,Other
+# default: Association,Company,NGO,Individual,Other
+#orgTypeValues=Association,Company,NGO,Individual,Other
+
 
 # Areas map configuration
 # This map appears on the /console/account/new page, when the user checks the "my org does not exist" checkbox.
 # Currently the map is configured with the EPSG:4326 SRS.
-# Optional center and zoom of map, uncomment following line and also AreaMapZoom to force center and zoom
+
+# Center of map
+# default: 1.77, 47.3
 #AreaMapCenter=1.77, 47.3
+
+# Zoom of map
+# default: 6
 #AreaMapZoom=6
+
 # AreasUrl is the URL of a static file or a service with a GeoJSON FeatureCollection object string in EPSG:4326.
-AreasUrl=https://www.geopicardie.fr/public/communes_simplified.json
 # example "dynamic" AreasUrl=https://my.server.org/geoserver/ows?SERVICE=WFS&REQUEST=GetFeature&typeName=gadm:gadm_for_countries&outputFormat=json&cql_filter=ISO='FRA' or ISO='BEL'
+# default: https://www.geopicardie.fr/public/communes_simplified.json
+#AreasUrl=https://www.geopicardie.fr/public/communes_simplified.json
+
 # The following properties are used to configure the map widget behavior:
-AreasKey=INSEE_COM
 # AreasKey is the key stored in the org LDAP record to uniquely identify a feature.
-AreasValue=NOM_COM
+# default: INSEE_COM
+#AreasKey=INSEE_COM
+
 # AreasValue is the feature "nice name" which appears in the widget list once selected.
-AreasGroup=NOM_DEP
+# default: NOM_COM
+#AreasValue=NOM_COM
+
 # AreasGroup is the feature property which is used to group together areas.
 # eg: if the GeoJSON file represents regions, then AreasGroup might be the property with the "state name".
 # CAUTION: AreasGroup **has to** be a string, not a numeric !
+# default: NOM_DEP
+AreasGroup=NOM_DEP
+
 
 # reCaptcha V2
-recaptcha.activated=false
-verificationURL=https://www.google.com/recaptcha/api/siteverify
-privateKey=6LfTgF4UAAAAAL-FJJecf36W69hEaC4qZ1yu_s5-
-publicKey=6LfTgF4UAAAAADphdZKi6ocxIpn9MSzt8wRBFmmd
+
+# Activate reCaptcha
+# default: false
+#recaptcha.activated=false
+
+# reCaptcha verification URL
+# default: https://www.google.com/recaptcha/api/siteverify
+#verificationURL=https://www.google.com/recaptcha/api/siteverify
+
+# reCaptcha private key
+# default: 6LfTgF4UAAAAAL-FJJecf36W69hEaC4qZ1yu_s5-
+#privateKey=6LfTgF4UAAAAAL-FJJecf36W69hEaC4qZ1yu_s5-
+
+# reCaptcha public key
+# default: 6LfTgF4UAAAAADphdZKi6ocxIpn9MSzt8wRBFmmd
+#publicKey=6LfTgF4UAAAAADphdZKi6ocxIpn9MSzt8wRBFmmd
+
 
 # LDAP related
-ldapUrl=ldap://localhost:389
-baseDN=dc=georchestra,dc=org
-ldapAdminDn=cn=admin,dc=georchestra,dc=org
-ldap.admin.password=secret
-# LDAP organizational units:
-userSearchBaseDN=ou=users
-roleSearchBaseDN=ou=roles
-orgSearchBaseDN=ou=orgs
-pendingUserSearchBaseDN=ou=pendingusers
-pendingOrgSearchBaseDN=ou=pendingorgs
+
+# URL of LDAP server
+# default: ldap://localhost:389
+#ldapUrl=ldap://localhost:389
+
+# Base DN of the LDAP directory
+# default: dc=georchestra,dc=org
+#baseDN=dc=georchestra,dc=org
+
+# User to connect to the LDAP
+# default: cn=admin,dc=georchestra,dc=org
+#ldapAdminDn=cn=admin,dc=georchestra,dc=org
+
+# Password to connect to the LDAP
+# default: secret
+#ldap.admin.password=secret
+
+
+# LDAP organizational units
+
+# Users
+# default: ou=users
+#userSearchBaseDN=ou=users
+
+# Roles
+# default: ou=roles
+#roleSearchBaseDN=ou=roles
+
+# Organizations
+# default: ou=orgs
+#orgSearchBaseDN=ou=orgs
+
+# Pending users
+# default: ou=pendingusers
+#pendingUserSearchBaseDN=ou=pendingusers
+
+# Pending organizations
+# default: ou=pendingorgs
+#pendingOrgSearchBaseDN=ou=pendingorgs
+
 
 # PostGreSQL database connection parameters
-psql.url=jdbc:postgresql://localhost:5432/georchestra
-psql.user=georchestra
-psql.pass=georchestra
-dataSource.minPoolSize = 2
+
+# URL of PostGreSQL server
+# default: jdbc:postgresql://localhost:5432/georchestra
+#psql.url=jdbc:postgresql://localhost:5432/georchestra
+
+# User to connect to PostGreSQL server
+# default: georchestra
+#psql.user=georchestra
+
+# Password to connect to PostGreSQL server
+# default: georchestra
+#psql.pass=georchestra
+
+# Minimum connections pool size
+# default: 2
+#dataSource.minPoolSize = 2
+
+# Maximum connections pool size
+# default: 10
 dataSource.maxPoolSize = 10
-#acquire connection timeout (in ms for c3p0)
+
+# Acquire connection timeout (in ms for c3p0)
+# default: 1000
 dataSource.timeout = 1000
-#max time unused connections are kept idle in the pool. Unit is seconds for c3p0.
+
+# Max time unused connections are kept idle in the pool. Unit is seconds for c3p0.
+# default: 60
 dataSource.maxIdleTime=60
 
 
 # SMTP configuration
-smtpHost=localhost
-smtpPort=25
+
+# SMTP server domain name
+# default: localhost
+#smtpHost=localhost
+
+# SMTP server port
+# default: 25
+#smtpPort=25
+
 
 # Email-related properties
-emailHtml=false
-replyTo=georchestra+testadmin@georchestra.mydomain.org
-from=georchestra+testadmin@georchestra.mydomain.org
-subject.account.created=[geOrchestra] Your account has been created
-subject.account.in.process=[geOrchestra] Your new account is waiting for validation
-subject.requires.moderation=[geOrchestra] New account waiting for validation
-subject.change.password=[geOrchestra] Update your password
-subject.account.uid.renamed=[geOrchestra] New login for your account
-subject.new.account.notification=[geOrchestra] New account created
-templateEncoding=UTF-8
-warnUserIfUidModified=true
+
+# Send emails in HTML format
+# default: false
+#emailHtml=false
+
+# Reply-To field in sent emails
+# default: georchestra+testadmin@georchestra.mydomain.org
+#replyTo=georchestra+testadmin@georchestra.mydomain.org
+
+# From field in sent emails
+# default: georchestra+testadmin@georchestra.mydomain.org
+#from=georchestra+testadmin@georchestra.mydomain.org
+
+# Subject of email when your account has been created
+# default: [geOrchestra] Your account has been created
+#subject.account.created=[geOrchestra] Your account has been created
+
+# Subject of email when your account creation is waiting for validation
+# default: [geOrchestra] Your new account is waiting for validation
+#subject.account.in.process=[geOrchestra] Your new account is waiting for validation
+
+# Subject of email for moderator at account creation
+# default: [geOrchestra] New account waiting for validation
+#subject.requires.moderation=[geOrchestra] New account waiting for validation
+
+# Subject of email for password change
+# default: [geOrchestra] Update your password
+#subject.change.password=[geOrchestra] Update your password
+
+# Subject of email for login change
+# default: [geOrchestra] New login for your account
+#subject.account.uid.renamed=[geOrchestra] New login for your account
+
+# Subject of email when a new account has been created
+# default: [geOrchestra] New account created
+#subject.new.account.notification=[geOrchestra] New account created
+
+# Encoding of the email templates
 # This "é" char should display nicely in a ISO 8859-1 configured editor
+# default: UTF-8
+#templateEncoding=UTF-8
+
+# Warn a user if their login has been modified
+# default: true
+#warnUserIfUidModified=true
+
 
 # Email proxy configuration
 # Basically, this webapp can send emails on behalf of LDAP users.
@@ -112,9 +247,24 @@ warnUserIfUidModified=true
 # Usage is restricted to users having the MOD_EMAILPROXY role by default,
 # cf https://github.com/georchestra/datadir/blob/master/security-proxy/security-mappings.xml
 # see https://github.com/georchestra/georchestra/pull/1572 for more information.
-emailProxyFromAddress=no-reply@georchestra.org
-emailProxyMaxRecipient=10
-emailProxyMaxBodySize=10000
-emailProxyMaxSubjectSize=200
-emailProxyRecipientWhitelist=psc@georchestra.org, postmaster@georchestra.org, listmaster@georchestra.org
-# these restrictions have been implemented to prevent spammers.
+# The following restrictions have been implemented to prevent spammers.
+
+# From field in sent emails
+# default: no-reply@georchestra.org
+#emailProxyFromAddress=no-reply@georchestra.org
+
+# Maximum number of recipients
+# default: 10
+#emailProxyMaxRecipient=10
+
+# Maximum email body size
+# default: 10000
+#emailProxyMaxBodySize=10000
+
+# Maximum email subject size
+# 200
+#emailProxyMaxSubjectSize=200
+
+# List of allowed recipients of emails
+# default: psc@georchestra.org, postmaster@georchestra.org, listmaster@georchestra.org
+#emailProxyRecipientWhitelist=psc@georchestra.org, postmaster@georchestra.org, listmaster@georchestra.org

--- a/console/console.properties
+++ b/console/console.properties
@@ -87,7 +87,7 @@
 # eg: if the GeoJSON file represents regions, then AreasGroup might be the property with the "state name".
 # CAUTION: AreasGroup **has to** be a string, not a numeric !
 # default: NOM_DEP
-AreasGroup=NOM_DEP
+#AreasGroup=NOM_DEP
 
 
 # reCaptcha V2
@@ -179,7 +179,7 @@ dataSource.timeout = 1000
 
 # Max time unused connections are kept idle in the pool. Unit is seconds for c3p0.
 # default: 60
-dataSource.maxIdleTime=60
+#dataSource.maxIdleTime=60
 
 
 # SMTP configuration

--- a/console/console.properties
+++ b/console/console.properties
@@ -171,11 +171,11 @@
 
 # Maximum connections pool size
 # default: 10
-dataSource.maxPoolSize = 10
+#dataSource.maxPoolSize = 10
 
 # Acquire connection timeout (in ms for c3p0)
 # default: 1000
-dataSource.timeout = 1000
+#dataSource.timeout = 1000
 
 # Max time unused connections are kept idle in the pool. Unit is seconds for c3p0.
 # default: 60

--- a/default.properties
+++ b/default.properties
@@ -12,5 +12,6 @@ language=en
 
 # Header height (size in px)
 headerHeight=90
+
 # Header URL (can be absolute or relative)
 headerUrl=/header/

--- a/extractorapp/extractorapp.properties
+++ b/extractorapp/extractorapp.properties
@@ -65,7 +65,7 @@
 # Max extraction size in pixels
 
 # Maximum coverage extraction size
-# default: 
+# default:
 maxCoverageExtractionSize=99999999
 maxCoverageExtractionSize=99999999
 

--- a/extractorapp/extractorapp.properties
+++ b/extractorapp/extractorapp.properties
@@ -65,9 +65,8 @@
 # Max extraction size in pixels
 
 # Maximum coverage extraction size
-# default:
-maxCoverageExtractionSize=99999999
-maxCoverageExtractionSize=99999999
+# default: 99999999
+#maxCoverageExtractionSize=99999999
 
 # Maximum number of extractions
 # default: 100

--- a/extractorapp/extractorapp.properties
+++ b/extractorapp/extractorapp.properties
@@ -1,33 +1,100 @@
-# Uncomment to override default values (see default.properties)
-# publicUrl=https://georchestra.mydomain.org
-# language=en
+# URL of the geOrchestra instance
+# default: https://georchestra.mydomain.org, see default.properties
+#publicUrl=https://georchestra.mydomain.org
+
+# Language of the interface
+# default: en, see default.properties
+#language=en
+
 
 # Email properties
-smtpHost=localhost
-smtpPort=25
-replyTo=psc@georchestra.org
-from=psc@georchestra.org
-emailHtml=false
 
-privileged_admin_name=geoserver_privileged_user
-privileged_admin_pass=gerlsSnFd6SmM
+# SMTP server domain name
+# default: localhost
+#smtpHost=localhost
+
+# SMTP server port
+# default: 25
+#smtpPort=25
+
+# ReplyTo field in sent emails
+# default: psc@georchestra.org
+#replyTo=psc@georchestra.org
+
+# From field in sent emails
+# default: psc@georchestra.org
+#from=psc@georchestra.org
+
+# Send emails in HTML format
+# default: false
+#emailHtml=false
+
+
+# GeoServer admin username
+# default: geoserver_privileged_user
+#privileged_admin_name=geoserver_privileged_user
+
+# GeoServer admin password
+# default: gerlsSnFd6SmM
+#privileged_admin_pass=gerlsSnFd6SmM
+
 
 # Link to DB to store extraction statistics in 'extractorapp' schema
-jdbcurl=jdbc:postgresql://localhost:5432/georchestra?user=georchestra&password=georchestra
-dataSource.minPoolSize=1
-dataSource.maxPoolSize=10
-dataSource.timeout=2000
-#max time unused connections are kept idle in the pool. Unit is seconds for c3p0.
-dataSource.maxIdleTime=60
 
-# max extraction size in pixels
+# PostGreSQL server URL
+# default: jdbc:postgresql://localhost:5432/georchestra?user=georchestra&password=georchestra
+#jdbcurl=jdbc:postgresql://localhost:5432/georchestra?user=georchestra&password=georchestra
+
+# Minimum connections pool size
+# default: 1
+#dataSource.minPoolSize=1
+
+# Maximum connections pool size
+# default: 10
+#dataSource.maxPoolSize=10
+
+# Connections pool timeout (ms)
+# default: 2000
+#dataSource.timeout=2000
+
+# Max time unused connections are kept idle in the pool. Unit is seconds for c3p0.
+# default: 60
+#dataSource.maxIdleTime=60
+
+
+# Max extraction size in pixels
+
+# Maximum coverage extraction size
+# default: 
 maxCoverageExtractionSize=99999999
-maxExtractions=100
-remoteReproject=true
-useCommandLineGDAL=false
-extractionFolderPrefix=extraction-
-emailfactory=org.georchestra.extractorapp.ws.EmailFactoryDefault
-emailsubject=[geOrchestra] Your extraction request
+maxCoverageExtractionSize=99999999
 
-# extractionManager bean
-minThreads=1
+# Maximum number of extractions
+# default: 100
+#maxExtractions=100
+
+# Allow remote reprojection
+# default: true
+#remoteReproject=true
+
+# Use command line GDAL
+# default: false
+#useCommandLineGDAL=false
+
+# Extraction folder prefix
+# default: extraction-
+#extractionFolderPrefix=extraction-
+
+# Subject of the extraction emails
+# default: [geOrchestra] Your extraction request
+#emailsubject=[geOrchestra] Your extraction request
+
+
+# Minimum number of threads for extractionManager bean
+# default: 1
+#minThreads=1
+
+
+# Deprecated
+
+#emailfactory=org.georchestra.extractorapp.ws.EmailFactoryDefault

--- a/geowebcache/geowebcache.properties
+++ b/geowebcache/geowebcache.properties
@@ -8,4 +8,4 @@
 
 # Context path of the application
 # default: /geowebcache
-contextPath=/geowebcache
+#contextPath=/geowebcache

--- a/geowebcache/geowebcache.properties
+++ b/geowebcache/geowebcache.properties
@@ -1,7 +1,11 @@
+# Name of the geOrchestra instance
+# default: geOrchestra, see default.properties
+#instanceName=geOrchestra
+
+# Header height (in px)
+# default: 90, see default.properties
+#headerHeight=90
+
+# Context path of the application
+# default: /geowebcache
 contextPath=/geowebcache
-
-# Name of this instance. Uncomment to override default value
-# instanceName=geOrchestra
-
-# Header height (size in px). Uncomment to override default value
-# headerHeight=90

--- a/header/header.properties
+++ b/header/header.properties
@@ -1,4 +1,7 @@
-# Uncomment to override default values (see default.properties)
-# language=en
+# Language of the interface
+# default: en, see default.properties
+#language=en
 
-consolePublicContextPath=/console
+# Context path of the console application
+# default: /console
+#consolePublicContextPath=/console

--- a/mapfishapp/mapfishapp.properties
+++ b/mapfishapp/mapfishapp.properties
@@ -1,29 +1,56 @@
-# Uncomment to override default values (see default.properties)
-# instanceName=geOrchestra
-# language=en
-# headerHeight=90
-# headerUrl=/header/
+# Name of the geOrchestra instance
+# default: geOrchestra, see default.properties
+#instanceName=geOrchestra
 
-jdbcUrl=jdbc:postgresql://localhost:5432/georchestra?user=georchestra&password=georchestra
-dataSource.minPoolSize=1
-dataSource.maxPoolSize=10
-dataSource.timeout=2000
-#max time unused connections are kept idle in the pool. Unit is seconds for c3p0.
-dataSource.maxIdleTime=60
+# Language of the interface
+# default: en, see default.properties
+#language=en
+
+# Header height (in px)
+# default: 90, see default.properties
+#headerHeight=90
+
+# Header URL (can be absolute or relative)
+# default: /header/, see default.properties
+#headerUrl=/header/
 
 
-docTempDir=/tmp
+# PostGreSQL server URL
+# default: jdbc:postgresql://localhost:5432/georchestra?user=georchestra&password=georchestra
+#jdbcUrl=jdbc:postgresql://localhost:5432/georchestra?user=georchestra&password=georchestra
+
+# Minimum connections pool size
+# default: 1
+#dataSource.minPoolSize=1
+
+# Maximum connections pool size
+# default: 10
+#dataSource.maxPoolSize=10
+
+# Timeout in connections pool (ms)
+# default: 2000
+#dataSource.timeout=2000
+
+# Max time unused connections are kept idle in the pool. Unit is seconds for c3p0.
+# default: 60
+#dataSource.maxIdleTime=60
+
+
+# Directory for temporary documents
+# default: /tmp
+#docTempDir=/tmp
 
 # Maximum file size the backend accepts for uploaded files
-# Default is 8388608
 # Set to -1 to indicate no limit
 # See also: https://docs.spring.io/autorepo/docs/spring-framework/3.1.0.RELEASE/javadoc-api/org/springframework/web/multipart/commons/CommonsFileUploadSupport.html#setMaxUploadSize(long)
 # Complement: if you use Apache2 or nginx as a proxy server in front of geOrchestra, check if it doesn't also limit the length of the requests (possibly generating a 413 HTTP status code)
 #    - in Apache2, see the LimitRequestBody property
 #    - in nginx, see the client_max_body_size property
 #    Note that HAProxy does not provide such an option.
-maxUploadSize=8388608
+# default: 8388608
+#maxUploadSize=8388608
+
 # The maximum in memory size allowed
-# Default is 10240
 # See also: see https://docs.spring.io/autorepo/docs/spring-framework/3.1.0.RELEASE/javadoc-api/org/springframework/web/multipart/commons/CommonsFileUploadSupport.html#setMaxInMemorySize(int)
-maxInMemorySize=10240
+# default:10240
+#maxInMemorySize=10240

--- a/security-proxy/security-proxy.properties
+++ b/security-proxy/security-proxy.properties
@@ -1,65 +1,135 @@
 # ------   proxy-servlet.xml   ---------
-# default timeout : 20min should be enough to handle big extraction (~ 4x10^9 pixels)
-http_client_timeout=1200000
+
+# Default timeout : 20min should be enough to handle big extraction (~ 4x10^9 pixels)
+# default: 1200000
+#http_client_timeout=1200000
+
 
 # -------  applicationContext-security.xml   -------
-anonymousRole=ROLE_ANONYMOUS
-proxy.contextPath=/sec
-# url called when user has logged out
-logout-success-url=https://georchestra.mydomain.org/cas/logout?fromgeorchestra
-# url where the user can login
-casLoginUrl=https://georchestra.mydomain.org/cas/login
-# url that the security system uses to validate the cas tickets
-casTicketValidation=https://georchestra.mydomain.org/cas
+
+# Anonymous role
+# default: ROLE_ANONYMOUS
+#anonymousRole=ROLE_ANONYMOUS
+
+# Proxy context path
+# default: /sec
+#proxy.contextPath=/sec
+
+# URL called when user has logged out
+# default: https://georchestra.mydomain.org/cas/logout?fromgeorchestra
+#logout-success-url=https://georchestra.mydomain.org/cas/logout?fromgeorchestra
+
+# URL where the user can login
+# default: https://georchestra.mydomain.org/cas/login
+#casLoginUrl=https://georchestra.mydomain.org/cas/login
+
+# URL that the security system uses to validate the cas tickets
+# default: https://georchestra.mydomain.org/cas
+#casTicketValidation=https://georchestra.mydomain.org/cas
+
 # After going to the cas login cas forwards to this URL where the authorities and permissions are checked
-proxyCallback=https://georchestra.mydomain.org/login/cas
-# list of trusted proxy, all request from listed server will be trusted and will bypass security
-trustedProxy=127.0.0.1, localhost
-# the ldap url
-ldapUrl=ldap://localhost
-baseDN=dc=georchestra,dc=org
-# The base DN from where to search for the logged in user.  This mostly to verify the user exists
-userSearchBaseDN=ou=users
-# The base DN from where to search for organization. Use to fill sec-org http header
-orgSearchBaseDN=ou=orgs
-# the second part of looking up the user
-userSearchFilter=(uid={0})
+# default: https://georchestra.mydomain.org/login/cas
+#proxyCallback=https://georchestra.mydomain.org/login/cas
+
+# List of trusted proxies, all requests from listed server will be trusted and
+# will bypass security
+# default: 127.0.0.1, localhost
+#trustedProxy=127.0.0.1, localhost
+
+
+# LDAP
+
+# URL of the LDAP server
+# default: ldap://localhost
+#ldapUrl=ldap://localhost
+
+# Base DN of the LDAP directory
+# default: dc=georchestra,dc=org
+#baseDN=dc=georchestra,dc=org
+
+# The base DN from where to search for the logged in user.
+# This mostly to verify the user exists
+# default: ou=users
+#userSearchBaseDN=ou=users
+
+# The base DN from where to search for organization.
+# Use to fill sec-org http header
+# default: ou=orgs
+#orgSearchBaseDN=ou=orgs
+
+# The second part of looking up the user
+# default: (uid={0})
+#userSearchFilter=(uid={0})
+
 # The base DN to use for looking up the roles/groups/authorities of the logged in user. Normally the ldap is configured like:
 #   ou=roles
 #     cn=somerole
 #       member=uid=username,ou=users,dc=georchestra,dc=org
 #
 #   ou can be cn, ou, or some other option. member is often uniquemember as well.
-authoritiesBaseDN=ou=roles
+# default: ou=roles
+#authoritiesBaseDN=ou=roles
+
 # The attribute of the role which is the rolename
-roleRoleAttribute=cn
-# the search filter that selects the roles that the user belongs to.
+# default: cn
+#roleRoleAttribute=cn
+
+# The search filter that selects the roles that the user belongs to.
 # If a match is found, the containing object is one of the roles the user belongs to
-roleSearchFilter=(member=uid={1},ou=users,dc=georchestra,dc=org)
+# default: (member=uid={1},ou=users,dc=georchestra,dc=org)
+#roleSearchFilter=(member=uid={1},ou=users,dc=georchestra,dc=org)
+
 # the admin user's DN (distinguished name)
 #    Depending on how the LDAP is configured you may be able to comment this and password out and add
 #     <property name="anonymousReadOnly" value="true" />
 #    to the "ldapContextSource" bean
-ldapAdminDn=cn=admin,dc=georchestra,dc=org
+# default: cn=admin,dc=georchestra,dc=org
+#ldapAdminDn=cn=admin,dc=georchestra,dc=org
+
 # The password for binding to the admin user in the ldap
-ldap.admin.password=secret
+# default: secret
+#ldap.admin.password=secret
 
 
-realmName=georchestra
+# Name of the realm
+# default: georchestra
+#realmName=georchestra
 
-# The security-proxy will 302 redirect / to the defaultTarget value (/header by default).
+# The security-proxy will 302 redirect / to the defaultTarget value.
 # Change it if your homepage (eg a CMS) is located on /portal/ for instance
-defaultTarget=/header/
+# default: /header/
+#defaultTarget=/header/
+
 
 # Connection pool settings for the logger appender that inserts OGC request stats on the database
-ogcStats.jdbcURL=jdbc:postgresql://database:5432/georchestra
-ogcStats.databaseUser=georchestra
-ogcStats.databasePassword=georchestra
-ogcStats.minPoolSize=1
-ogcStats.maxPoolSize=5
-ogcStats.timeout=2000
-#max time unused connections are kept idle in the pool. Unit is seconds for c3p0.
-ogcStats.maxIdleTime=60
+
+# OGC database URL
+# default: jdbc:postgresql://database:5432/georchestra
+#ogcStats.jdbcURL=jdbc:postgresql://database:5432/georchestra
+
+# User
+# default: georchestra
+#ogcStats.databaseUser=georchestra
+
+# Password
+# default: georchestra
+#ogcStats.databasePassword=georchestra
+
+# Minimum connections pool size
+# default: 1
+#ogcStats.minPoolSize=1
+
+# Maximum connections pool size
+# default: 5
+#ogcStats.maxPoolSize=5
+
+# Timeout of connections pool
+# default: 2000
+#ogcStats.timeout=2000
+
+# Max time unused connections are kept idle in the pool. Unit is seconds for c3p0.
+# default: 60
+#ogcStats.maxIdleTime=60
 
 # A comma-separated list of privileged users that are allowed to impersonate other users
 # default: geoserver_privileged_user


### PR DESCRIPTION
Since a default value is set in the geOrchestra code when any property
is loaded from a properties file, it's not necessary to provide it also
in the datadir properties files, unless it is different from the default.

It also makes it easier for the instance administrator to review their
datadir, focusing only on important properties, and letting the default
values unchanged for the rest of the properties.

See https://github.com/georchestra/datadir/issues/129 for the
motivation.

Note that the default.properties file has been let uncommented, as we
always want these values to be set by the instance administrator.