### PR TITLE
GeoServer configuration for S3 GeoTiff module

### DIFF
--- a/geoserver/s3-geotiff/s3-geotiff-ehcache.xml
+++ b/geoserver/s3-geotiff/s3-geotiff-ehcache.xml
@@ -1,0 +1,26 @@
+<!-- Cache configuration for the s3-geotiff geoserver extension. -->
+<ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="ehcache.xsd">
+
+	<diskStore path="java.io.tmpdir" />
+
+	<!-- This cache contains a maximum in memory of 200MB elements, and will 
+		expire an element if it is idle for more than 5 minutes and lives for more 
+		than 10 minutes. 
+		If there are more than 200MB on the heap cache it will overflow to 
+		the disk cache, which in this configuration will go to wherever java.io.tmp 
+		is defined on your system. On a standard Linux system this will be /tmp.
+		See http://www.ehcache.org/ehcache.xml for more information on properties.
+	-->
+	<cache 	name="default_cache" 
+			maxBytesLocalHeap="200M"
+			maxBytesLocalDisk="2G" 
+			eternal="false" 
+			diskSpoolBufferSizeMB="20"
+			timeToIdleSeconds="300" 
+			timeToLiveSeconds="600"
+			memoryStoreEvictionPolicy="LFU" 
+			transactionalMode="off">
+		<persistence strategy="localTempSwap" />
+	</cache>
+</ehcache>

--- a/geoserver/s3-geotiff/s3.properties
+++ b/geoserver/s3-geotiff/s3.properties
@@ -1,0 +1,11 @@
+#Example properties
+#Define server aliases to access geotiffs on S3 servers not hosted on Amazon, e.g. https://www.minio.io/ or other. 
+#Using the below configuration, the files on the S3 service can be accessed with the following 
+#URL style configuration in geoserver: main://bucketname/filename.tiff, where main is the alias for the server.
+main.s3.endpoint=http://your-s3-server
+main.s3.user=your-s3-user
+main.s3.password=your-s3-password
+
+other.s3.endpoint=http://your-other-s3-server
+other.s3.user=your-other-s3-user
+other.s3.password=your-other-s3-passwordr


### PR DESCRIPTION
Add the s3-geotiff cache and server aliases configuration files to geoserver's georchestra datadir.
They aren't mandatory, but the cache configuration file has better defaults for an actual deployment than the `gt-s3-geotiff` hardcoded defaults.