### PR TITLE
geonetwork - finally move harvester logs to a dedicated dir

### DIFF
--- a/geonetwork/log4j/log4j.xml
+++ b/geonetwork/log4j/log4j.xml
@@ -1,12 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 <log4j:configuration debug="false">
-  <appender name="consoleAppender" class="org.apache.log4j.ConsoleAppender">
-    <param name="Threshold" value="ALL" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="%d{ISO8601} %-5p [%c] - %m%n" />
-    </layout>
-  </appender>
+    <appender name="consoleAppender" class="org.apache.log4j.ConsoleAppender">
+        <param name="Threshold" value="ALL" />
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d{ISO8601} %-5p [%c] - %m%n" />
+        </layout>
+    </appender>
+    <appender name="harvesterAppender" class="org.apache.log4j.FileAppender">
+        <param name="Threshold" value="ALL" />
+        <param name="File" value="/mnt/geonetwork_datadir/harvester_logs/geonetwork-harvester.log" />
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d{ISO8601} %-5p [%c] - %m%n" />
+        </layout>
+    </appender>
    <!-- Geonetwork module (and submodule) logging -->
     <logger name="geonetwork" additivity="false">
         <level value="WARN" />
@@ -59,7 +66,7 @@
     </logger>
     <logger name="geonetwork.harvester" additivity="false">
         <level value="WARN" />
-        <appender-ref ref="consoleAppender" />
+        <appender-ref ref="harvesterAppender" />
     </logger>
     <logger name="geonetwork.lucene">
         <level value="WARN" />


### PR DESCRIPTION
finalizing work from #86  

Directory `/mnt/geonetwork_datadir/harvester_logs/` in volume should exist.

Will create it in https://github.com/georchestra/geonetwork_minimal_datadir & https://github.com/georchestra/geonetwork/blob/georchestra-gn3.4-19.04/web/src/docker/Dockerfile