### PR TITLE
security-proxy: Add allowSemicolon boolean property

### DIFF
--- a/security-proxy/security-proxy.properties
+++ b/security-proxy/security-proxy.properties
@@ -166,3 +166,7 @@
 # eg. userAgents=.*ArcGIS.*,.*uDig.*,.*QGIS.*
 # default: empty
 #userAgents=
+
+# Whether to allow semicolons in URLs to avoid erros like:
+# the request was rejected because the URL contained a potentially malicious String ";"
+# allowSemicolon=false


### PR DESCRIPTION
Indicates whether to allow semicolons in URLs to avoid erros like:
the request was rejected because the URL contained a potentially malicious String ";"