### PR TITLE
proxy - inverting the logic to filter access to /console/account/*

### DIFF
--- a/security-proxy/security-mappings.xml
+++ b/security-proxy/security-mappings.xml
@@ -11,12 +11,18 @@
   <intercept-url pattern="/console/public/.*" access="IS_AUTHENTICATED_ANONYMOUSLY" />
   <intercept-url pattern="/console/manager/public/.*" access="IS_AUTHENTICATED_ANONYMOUSLY" />
   <intercept-url pattern="/console/manager/.*" access="ROLE_SUPERUSER,ROLE_ORGADMIN" />
-  <intercept-url pattern="/console/account/userdetails" access="IS_AUTHENTICATED_FULLY" />
-  <intercept-url pattern="/console/account/changePassword" access="IS_AUTHENTICATED_FULLY" />
+  <!-- /console/account ressources are private except account/new and account/passwordRecovery -->
+  <intercept-url pattern="/console/account/new" access="IS_AUTHENTICATED_ANONYMOUSLY" />
+  <intercept-url pattern="/console/account/passwordRecovery" access="IS_AUTHENTICATED_ANONYMOUSLY" />
+  <intercept-url pattern="/console/account/js/.*" access="IS_AUTHENTICATED_ANONYMOUSLY" />
+  <intercept-url pattern="/console/account/css/.*" access="IS_AUTHENTICATED_ANONYMOUSLY" />
+  <intercept-url pattern="/console/account/.*" access="IS_AUTHENTICATED_FULLY" />
+  <!-- /console/sendEmail features are reserved to SUPERUSER & delefated admins -->
   <intercept-url pattern="/console/.*/emails" access="ROLE_SUPERUSER,ROLE_ORGADMIN" />
   <intercept-url pattern="/console/.*/sendEmail" access="ROLE_SUPERUSER,ROLE_ORGADMIN" />
   <intercept-url pattern="/console/attachments" access="ROLE_SUPERUSER,ROLE_ORGADMIN" />
   <intercept-url pattern="/console/emailTemplates" access="ROLE_SUPERUSER,ROLE_ORGADMIN" />
+  <!-- /console/emailProxy is activated for members having the EMAILPROXY role -->
   <intercept-url pattern="/console/emailProxy" access="ROLE_EMAILPROXY" />
   <intercept-url pattern="/testPage" access="IS_AUTHENTICATED_FULLY" />
   <intercept-url pattern=".*/ogcproxy/.*" access="ROLE_NO_ONE" />


### PR DESCRIPTION
Following the work on GDPR adding two extra services routed with the /console/account base path, security mappings need to be updated.

We need to have these services accessible for `IS_AUTHENTICATED_FULLY`
 * /console/account/userdetails
 * /console/account/changePassword
 * /console/account/gdpr/download
 * /console/account/gdpr/delete

And for `IS_AUTHENTICATED_ANONYMOUSLY`:
 * /console/account/new
 * /console/account/passwordRecovery

Hence the highest priority rule restricting access to `/console/account/.*` to  `IS_AUTHENTICATED_FULLY`

It's just unfortunate that public CSS and JS files are in the same path... see https://github.com/georchestra/georchestra/issues/2664 for improvements.