### PR TITLE
console: add default LDAP connection pool settings

### DIFF
--- a/console/console.properties
+++ b/console/console.properties
@@ -42,6 +42,25 @@
 # default: see default.properties - uncomment to override
 #ldapPort=
 
+# LDAP connection pool
+# Whether objects will be validated before being borrowed from the pool. If the object fails to validate, it will be dropped from the pool, and an attempt to borrow another will be made.
+#ldap.pool.testOnBorrow=true
+
+# maximum number of active connections of each type (read-only|read-write) that can be allocated from this pool at the same time, or -1 for no limit.
+#ldap.pool.maxActive=8
+
+# minimum number of active connections of each type (read-only|read-write) that can remain idle in the pool, without extra ones being created, or zero to create none.
+#ldap.pool.minIdle=1
+
+# maximum number of active connections of each type (read-only|read-write) that can remain idle in the pool, without extra ones being released, or -1 for no limit.
+#ldap.pool.maxIdle=8
+
+# overall maximum number of active connections (for all types) that can be allocated from this pool at the same time, or non-positive for no limit.
+#ldap.pool.maxTotal=-1
+
+# maximum number of milliseconds that the pool will wait (when there are no available connections) for a connection to be returned before throwing an exception, or -1 to wait indefinitely.
+#ldap.pool.maxWait=-1
+
 # Base DN of the LDAP directory
 # default: see default.properties - uncomment to override
 #ldapBaseDn=


### PR DESCRIPTION
Goes in tandem with https://github.com/georchestra/georchestra/pull/2861 to fix  https://github.com/georchestra/georchestra/issues/2487

Add default ldap connection pool settings to `console.properties`