### PR TITLE
Added commented overridable mapstore properties in geostore.properties

### DIFF
--- a/mapstore/geostore.properties
+++ b/mapstore/geostore.properties
@@ -1,3 +1,62 @@
 ### MapStore backend (GeoStore) properties
 # PostgreSQL schema used by the backend
 pgsqlGeoStoreSchema=geostore
+
+### The following properties are inherited from the geOrchestra default.properties,
+### if you want to override them for mapstore, uncomment them.
+# PostgreSQL server domain name
+# Domain name, or IP address, of the PostgreSQL server
+# pgsqlHost=localhost
+
+# PostgreSQL server port
+# Listening port of the PostgreSQL server
+# pgsqlPort=5432
+
+# PostgreSQL database name
+# Default common PostgreSQL database for all geOrchestra modules
+# pgsqlDatabase=georchestra
+
+# User to connect to PostgreSQL server
+# Default common PostgreSQL user for all geOrchestra modules
+# pgsqlUser=georchestra
+
+# Password to connect to PostgreSQL server
+# Default common password of PostgreSQL user for all geOrchestra modules
+# pgsqlPassword=georchestra
+
+### LDAP properties
+
+# LDAP server domain name
+# Domain name, or IP address, of the LDAP server
+# ldapHost=localhost
+
+# LDAP server port
+# Listening port of the LDAP server
+# ldapPort=389
+
+# LDAP Scheme
+# ldap or ldaps
+# ldapScheme=ldap
+
+# Base DN of the LDAP directory
+# Base Distinguished Name of the LDAP directory. Also named root or suffix, see
+# http://www.zytrax.com/books/ldap/apd/index.html#base
+# ldapBaseDn=dc=georchestra,dc=org
+
+# Administrator DN
+# Distinguished name of the administrator user that connects to the LDAP server
+# ldapAdminDn=cn=admin,dc=georchestra,dc=org
+
+# Administrator password
+# Password of the administrator user that connects to the LDAP server
+# ldapAdminPassword=secret
+
+# Users RDN
+# Relative distinguished name of the "users" LDAP organization unit. E.g. if the
+# complete name (or DN) is ou=users,dc=georchestra,dc=org, the RDN is ou=users.
+# ldapUsersRdn=ou=users
+
+# Roles RDN
+# Relative distinguished name of the "roles" LDAP organization unit. E.g. if the
+# complete name (or DN) is ou=roles,dc=georchestra,dc=org, the RDN is ou=roles.
+# ldapRolesRdn=ou=roles


### PR DESCRIPTION
As requested in https://github.com/georchestra/mapstore2-georchestra/issues/229.

Properties that can be overridden for mapstore (related to what is generally configured in default.properties) have been added to mapstore geostore.properties file.