### PR TITLE
proxy security mappings : rules on 'proxy' and 'login'

### DIFF
--- a/security-proxy/security-mappings.xml
+++ b/security-proxy/security-mappings.xml
@@ -1,6 +1,7 @@
 <http>
   <intercept-url pattern="/cas/login.*" access="IS_AUTHENTICATED_ANONYMOUSLY" />
-  <intercept-url pattern=".*\?.*login.*" access="ROLE_USER,ROLE_GN_EDITOR,ROLE_GN_REVIEWER,ROLE_GN_ADMIN,ROLE_ADMINISTRATOR,ROLE_SUPERUSER,ROLE_ORGADMIN" />
+  <intercept-url pattern="/proxy/\?url=.*" access="IS_AUTHENTICATED_ANONYMOUSLY" />
+  <intercept-url pattern=".*(/\?|&amp;)login.*" access="ROLE_USER,ROLE_GN_EDITOR,ROLE_GN_REVIEWER,ROLE_GN_ADMIN,ROLE_ADMINISTRATOR,ROLE_SUPERUSER,ROLE_ORGADMIN" />
   <intercept-url pattern="/extractorapp/admin.*" access="ROLE_ADMINISTRATOR" />
   <intercept-url pattern="/extractorapp/jobs/.*" access="ROLE_ADMINISTRATOR" />
   <intercept-url pattern="/extractorapp/.*" access="ROLE_EXTRACTORAPP" />


### PR DESCRIPTION
Adding a rule for requesting through proxy.
Improving rule on login to match only urls with '/login', '/?login', '&login'