### PR TITLE
Document support for extended header management

### DIFF
--- a/datafeeder/datafeeder.properties
+++ b/datafeeder/datafeeder.properties
@@ -76,4 +76,10 @@ datafeeder.publishing.backend.geoserver.passwd=${pgsqlPassword}
 datafeeder.publishing.backend.geoserver.[Loose\ bbox]=false
 datafeeder.publishing.backend.geoserver.[Estimated\ extends]=true
 
+logging.level.root=warn
+logging.level.org.springframework=warn
+logging.level.org.hibernate=error
+logging.level.org.georchestra.config.security=debug
+logging.level.org.georchestra.datafeeder=info
+logging.level.org.geoserver.openapi=info
 

--- a/security-proxy/headers-mapping.properties
+++ b/security-proxy/headers-mapping.properties
@@ -1,15 +1,91 @@
-# Keys are additional headers sent by the security-proxy,
-# mapped onto user's LDAP attributes.
+# Keys are additional headers sent by the security-proxy, mapped onto user's LDAP attributes:
+# Additionally, LDAP objects related to the authenticated user are accessible through
+# prefixed attribute names `manager.`, `org.`, and `org.seeAlso.`
+# 
+# Header names with no prefix (default headers) apply to all proxified services (e.g. sec-email=mail).
+# Header names prefixed with a service name as defined in targets-mapping.properties
+# complement the default headers when hitting a specific proxified servicei. for example:
+# analytics.sec-org-address=org.seeAlso.postalAddress
+# will also add the `sec-org-address` with the user organization's postal address as value
+# to requests hitting the analytics service.
+# 
+# Base64 header value encoding:
+# ============================
+# Due to HTTP headers being ISO-8859-1 encoded by spec, header values that can potentially have
+# characters outside that encoding can be configured to be base64-encoded. If so, the target service
+# must know how to decode them. For example:
+# sec-orgname=base64:org.o
+# will override the default sec-orgname header with a base64 encoded value.
 #
-# The following headers are already provided by the proxy,
-# regardless of this file's content:
-#  * sec-username
-#  * sec-roles
-#  * sec-org
-#  * sec-orgname
-#  * sec-proxy
+# Embedded headers:
+# =================
+# The following header mappings apply to all requests with no need of being configured in this file:
+# sec-username=uid
+# sec-roles (no specific mapping, contains the list of roles separated by `;`)
+# sec-org=org.cn
+# sec-orgname=org.o
 #
+# Authenticated user attribtues:
+# ==============================
+#uid
+#givenName
+#sn
+#cn
+#telephoneNumber
+#mail
+#postalAddress
+#description
+#title
+#objectClass
+#knowledgeInformation
+#
+# Authenticated user's manager attribtues
+# =======================================
+#manager.uid
+#manager.mail
+#manager.givenName
+#manager.description
+#manager.sn
+#manager.cn
+#manager.objectClass
+#
+# Authenticated user's organization attribtues
+# ============================================
+#org.cn
+#org.ou
+#org.o
+#org.member
+#org.description
+#org.objectClass
+#
+# Authenticated user's organization extended attribtues
+# =====================================================
+#org.seeAlso.o
+#org.seeAlso.labeledURI
+#org.seeAlso.businessCategory
+#org.seeAlso.postalAddress
+#org.seeAlso.description
+#org.seeAlso.knowledgeInformation
+#org.seeAlso.objectClass
+
 sec-email=mail
 sec-firstname=givenName
 sec-lastname=sn
 sec-tel=telephoneNumber
+
+# datafeeder service specific headers:
+datafeeder.sec-firstname=base64:givenName
+datafeeder.sec-lastname=base64:sn
+datafeeder.sec-tel=base64:telephoneNumber
+datafeeder.sec-email=mail
+datafeeder.sec-address=base64:postalAddress
+datafeeder.sec-title=base64:title
+datafeeder.sec-notes=base64:knowledgeInformation
+datafeeder.sec-orgname=base64:org.o
+datafeeder.sec-org-linkage=base64:org.seeAlso.labeledURI
+datafeeder.sec-org-address:base64:org.seeAlso.postalAddress
+datafeeder.sec-org-category:base64:org.seeAlso.businessCategory
+datafeeder.sec-org-description:base64:org.seeAlso.description
+datafeeder.sec-org-notes:base64:org.seeAlso.knowledgeInformation
+
+


### PR DESCRIPTION
- Document support for per-service headers
- Document support for base64 header encoding
- Document support for exentended organization and
  manager headers
- Document all valid LDAP properties available to set
  up request headers
- Add datafeeder specific header mappings