### PR TITLE
[datafeeder] Externalize auth config of geoserver and geonetwork REST clients

### DIFF
--- a/datafeeder/datafeeder.properties
+++ b/datafeeder/datafeeder.properties
@@ -37,9 +37,33 @@ front-end.config.uri=file:${georchestra.datadir}/datafeeder/frontend-config.json
 
 datafeeder.publishing.geoserver.api-url=http://geoserver:8080/geoserver/rest
 datafeeder.publishing.geoserver.public-url=${scheme}://${domainName}/geoserver
+# Use this for HTTP basic authentication to geoserver api url:
+#datafeeder.publishing.geoserver.auth.type=basic
+#datafeeder.publishing.geoserver.auth.basic.username=geoserver_privileged_user
+#datafeeder.publishing.geoserver.auth.basic.password=gerlsSnFd6SmM
+# Use this for HTTP-headers based authentication to GeoServer's api url:
+datafeeder.publishing.geoserver.auth.type=headers
+datafeeder.publishing.geoserver.auth.headers.[sec-proxy]=true
+datafeeder.publishing.geoserver.auth.headers.[sec-username]=datafeeder-application
+datafeeder.publishing.geoserver.auth.headers.[sec-roles]=ROLE_ADMINISTRATOR
+
 
 datafeeder.publishing.geonetwork.api-url=http://geonetwork:8080/geonetwork
 datafeeder.publishing.geonetwork.public-url=${scheme}://${domainName}/geonetwork
+# Use this for HTTP basic authentication to Geonetwork's api url:
+#datafeeder.publishing.geonetwork.auth.type=basic
+#datafeeder.publishing.geonetwork.auth.basic.username=
+#datafeeder.publishing.geonetwork.auth.basic.password=
+# Use this for HTTP-headers based authentication to Geonetwork's api url:
+datafeeder.publishing.geonetwork.auth.type=headers
+datafeeder.publishing.geonetwork.auth.headers.[sec-proxy]=true
+datafeeder.publishing.geonetwork.auth.headers.[sec-username]=testadmin
+datafeeder.publishing.geonetwork.auth.headers.[sec-org]=Datafeeder Test
+datafeeder.publishing.geonetwork.auth.headers.[sec-roles]=ROLE_ADMINISTRATOR;ROLE_GN_ADMIN
+# This is odd, apparently any UUID works as XSRF token, and these two need to be set
+datafeeder.publishing.geonetwork.auth.headers.[X-XSRF-TOKEN]=c9f33266-e242-4198-a18c-b01290dce5f1
+datafeeder.publishing.geonetwork.auth.headers.[Cookie]=XSRF-TOKEN=c9f33266-e242-4198-a18c-b01290dce5f1
+
 #template-record-id, an existing geonetwork record id to use as template. If provided, takes precedence over template-record 
 #datafeeder.publishing.geonetwork.template-record-id:
 datafeeder.publishing.geonetwork.template-record: file:${georchestra.datadir}/datafeeder/metadata_template.xml


### PR DESCRIPTION
Add basic and headers auth config properties.

Use externalized configuration to set up authentication for both the
GeoServer and GeoNetwork REST clients, using the following configuration
in `datafeeder.properties`:

```
datafeeder.publishing.geoserver.auth.type=basic|headers
datafeeder.publishing.geoserver.auth.basic.username=<username>
datafeeder.publishing.geoserver.auth.basic.password=<pwd>
datafeeder.publishing.geoserver.auth.headers.[<header-name>]=<header-value>

datafeeder.publishing.geonetwork.auth.type=basic|headers
datafeeder.publishing.geonetwork.auth.basic.username=<username>
datafeeder.publishing.geonetwork.auth.basic.password=<pwd>
datafeeder.publishing.geonetwork.auth.headers.[<header-name>]=<header-value>
```