### PR TITLE
Backport datafeeder configuration to master

### DIFF
--- a/datafeeder/datafeeder.properties
+++ b/datafeeder/datafeeder.properties
@@ -40,6 +40,11 @@ datafeeder.publishing.geoserver.public-url=${scheme}://${domainName}/geoserver
 
 datafeeder.publishing.geonetwork.api-url=http://geonetwork:8080/geonetwork
 datafeeder.publishing.geonetwork.public-url=${scheme}://${domainName}/geonetwork
+#template-record-id, an existing geonetwork record id to use as template. If provided, takes precedence over template-record 
+#datafeeder.publishing.geonetwork.template-record-id:
+datafeeder.publishing.geonetwork.template-record: file:${georchestra.datadir}/datafeeder/metadata_template.xml
+datafeeder.publishing.geonetwork.template-transform: file:${georchestra.datadir}/datafeeder/metadata_transform.xsl
+
 
 # GeoTools DataStore connection params used inside datafeeder when importing
 # uploaded datasets to the target store

--- a/datafeeder/datafeeder.properties
+++ b/datafeeder/datafeeder.properties
@@ -107,7 +107,7 @@ datafeeder.email.analysisFailedTemplate=file:${georchestra.datadir}/datafeeder/t
 datafeeder.email.publishFailedTemplate=file:${georchestra.datadir}/datafeeder/templates/data-publishing-failed-email-template.txt
 datafeeder.email.publishSuccessTemplate=file:${georchestra.datadir}/datafeeder/templates/data-publishing-succeeded-email-template.txt
 
-administratorEmail=georchestra@georchestra.mydomain.org
+#administratorEmail=georchestra@georchestra.mydomain.org
 
 # Configuration for SMTP email sending of application events
 # Datafeeder will send emails to the user when a job is started, finished, or failed,

--- a/datafeeder/datafeeder.properties
+++ b/datafeeder/datafeeder.properties
@@ -32,6 +32,8 @@ file-upload.file-size-threshold=1MB
 file-upload.temporary-location=${java.io.tmpdir}/datafeeder/tmp
 # directory location where files will be stored.
 file-upload.persistent-location=${java.io.tmpdir}/datafeeder/uploads
+# select the file to serve as the front-end application configuration
+front-end.config.uri=file:${georchestra.datadir}/datafeeder/frontend-config.json
 
 datafeeder.publishing.geoserver.api-url=http://geoserver:8080/geoserver/rest
 datafeeder.publishing.geoserver.public-url=${scheme}://${domainName}/geoserver

--- a/datafeeder/datafeeder.properties
+++ b/datafeeder/datafeeder.properties
@@ -37,9 +37,33 @@ front-end.config.uri=file:${georchestra.datadir}/datafeeder/frontend-config.json
 
 datafeeder.publishing.geoserver.api-url=http://geoserver:8080/geoserver/rest
 datafeeder.publishing.geoserver.public-url=${scheme}://${domainName}/geoserver
+# Use this for HTTP basic authentication to geoserver api url:
+#datafeeder.publishing.geoserver.auth.type=basic
+#datafeeder.publishing.geoserver.auth.basic.username=geoserver_privileged_user
+#datafeeder.publishing.geoserver.auth.basic.password=gerlsSnFd6SmM
+# Use this for HTTP-headers based authentication to GeoServer's api url:
+datafeeder.publishing.geoserver.auth.type=headers
+datafeeder.publishing.geoserver.auth.headers.[sec-proxy]=true
+datafeeder.publishing.geoserver.auth.headers.[sec-username]=datafeeder-application
+datafeeder.publishing.geoserver.auth.headers.[sec-roles]=ROLE_ADMINISTRATOR
+
 
 datafeeder.publishing.geonetwork.api-url=http://geonetwork:8080/geonetwork
 datafeeder.publishing.geonetwork.public-url=${scheme}://${domainName}/geonetwork
+# Use this for HTTP basic authentication to Geonetwork's api url:
+#datafeeder.publishing.geonetwork.auth.type=basic
+#datafeeder.publishing.geonetwork.auth.basic.username=
+#datafeeder.publishing.geonetwork.auth.basic.password=
+# Use this for HTTP-headers based authentication to Geonetwork's api url:
+datafeeder.publishing.geonetwork.auth.type=headers
+datafeeder.publishing.geonetwork.auth.headers.[sec-proxy]=true
+datafeeder.publishing.geonetwork.auth.headers.[sec-username]=testadmin
+datafeeder.publishing.geonetwork.auth.headers.[sec-org]=Datafeeder Test
+datafeeder.publishing.geonetwork.auth.headers.[sec-roles]=ROLE_ADMINISTRATOR;ROLE_GN_ADMIN
+# This is odd, apparently any UUID works as XSRF token, and these two need to be set
+datafeeder.publishing.geonetwork.auth.headers.[X-XSRF-TOKEN]=c9f33266-e242-4198-a18c-b01290dce5f1
+datafeeder.publishing.geonetwork.auth.headers.[Cookie]=XSRF-TOKEN=c9f33266-e242-4198-a18c-b01290dce5f1
+
 #template-record-id, an existing geonetwork record id to use as template. If provided, takes precedence over template-record 
 #datafeeder.publishing.geonetwork.template-record-id:
 datafeeder.publishing.geonetwork.template-record: file:${georchestra.datadir}/datafeeder/metadata_template.xml

--- a/datafeeder/datafeeder.properties
+++ b/datafeeder/datafeeder.properties
@@ -113,8 +113,8 @@ administratorEmail=georchestra@georchestra.mydomain.org
 # Datafeeder will send emails to the user when a job is started, finished, or failed,
 # if the spring.mail.* configuration properties are set.
 
-smtpHost=localhost
-smtpPort=25
+#smtpHost=localhost
+#smtpPort=25
 smtpUser=
 smtpPassword=
 smtpAuth=false

--- a/datafeeder/datafeeder.properties
+++ b/datafeeder/datafeeder.properties
@@ -33,21 +33,22 @@ file-upload.temporary-location=${java.io.tmpdir}/datafeeder/tmp
 # directory location where files will be stored.
 file-upload.persistent-location=${java.io.tmpdir}/datafeeder/uploads
 
-datafeeder.publishing.geoserver.api-url=http://localhost:8080/geoserver/rest
+datafeeder.publishing.geoserver.api-url=http://geoserver:8080/geoserver/rest
 datafeeder.publishing.geoserver.public-url=${scheme}://${domainName}/geoserver
 
-datafeeder.publishing.geonetwork.api-url=http://localhost:8081/geonetwork
+datafeeder.publishing.geonetwork.api-url=http://geonetwork:8080/geonetwork
 datafeeder.publishing.geonetwork.public-url=${scheme}://${domainName}/geonetwork
 
 # GeoTools DataStore connection params used inside datafeeder when importing
 # uploaded datasets to the target store
 datafeeder.publishing.backend.local.dbtype=postgis
-datafeeder.publishing.backend.local.host=localhost
-datafeeder.publishing.backend.local.port=5432
-datafeeder.publishing.backend.local.database=datafeeder
-datafeeder.publishing.backend.local.schema=public
-datafeeder.publishing.backend.local.user=postgres
-datafeeder.publishing.backend.local.passwd=postgres
+datafeeder.publishing.backend.local.host=${pgsqlHost}
+datafeeder.publishing.backend.local.port=${pgsqlPort}
+datafeeder.publishing.backend.local.database=${pgsqlDatabase}
+#<schema> is a placeholder to be replaced by the actual schema computed from the "sec-org" request header
+datafeeder.publishing.backend.geoserver.schema=<schema>
+datafeeder.publishing.backend.local.user=${pgsqlUser}
+datafeeder.publishing.backend.local.passwd=${pgsqlPassword}
 datafeeder.publishing.backend.local.preparedStatements=true
 
 # GeoTools DataStore connection params to be used when configuring a GeoServer
@@ -56,13 +57,13 @@ datafeeder.publishing.backend.geoserver.dbtype=postgis
 datafeeder.publishing.backend.geoserver.preparedStatements=true
 #<schema> is a placeholder to be replaced by the actual schema computed from the "sec-org" request header
 datafeeder.publishing.backend.geoserver.schema=<schema>
-datafeeder.publishing.backend.geoserver.jndiReferenceName=java:comp/env/jdbc/datafeeder
+#datafeeder.publishing.backend.geoserver.jndiReferenceName=java:comp/env/jdbc/datafeeder
 #if a JNDI data source is configured in geoserver, uncomment the above line and comment out the following ones 
-#datafeeder.publishing.backend.geoserver.host=localhost
-#datafeeder.publishing.backend.geoserver.port=5432
-#datafeeder.publishing.backend.geoserver.database=datafeeder
-#datafeeder.publishing.backend.geoserver.user=postgres
-#datafeeder.publishing.backend.geoserver.passwd=postgres
+datafeeder.publishing.backend.geoserver.host=${pgsqlHost}
+datafeeder.publishing.backend.geoserver.port=${pgsqlPort}
+datafeeder.publishing.backend.geoserver.database=${pgsqlDatabase}
+datafeeder.publishing.backend.geoserver.user=${pgsqlUser}
+datafeeder.publishing.backend.geoserver.passwd=${pgsqlPassword}
 
 # note how to set a property with spaces: property.prefix.[name\ with\ spaces]=value
 datafeeder.publishing.backend.geoserver.[Loose\ bbox]=false

--- a/datafeeder/datafeeder.properties
+++ b/datafeeder/datafeeder.properties
@@ -76,4 +76,10 @@ datafeeder.publishing.backend.geoserver.passwd=${pgsqlPassword}
 datafeeder.publishing.backend.geoserver.[Loose\ bbox]=false
 datafeeder.publishing.backend.geoserver.[Estimated\ extends]=true
 
+logging.level.root=warn
+logging.level.org.springframework=warn
+logging.level.org.hibernate=error
+logging.level.org.georchestra.config.security=debug
+logging.level.org.georchestra.datafeeder=info
+logging.level.org.geoserver.openapi=info
 

--- a/datafeeder/datafeeder.properties
+++ b/datafeeder/datafeeder.properties
@@ -1,0 +1,71 @@
+### The following properties are inherited from the geOrchestra default.properties,
+### if you want to override them for datafeeder, uncomment them.
+
+# PostgreSQL server domain name
+# pgsqlHost=database
+
+# PostgreSQL server port
+# pgsqlPort=5432
+
+# PostgreSQL database name
+# pgsqlDatabase=georchestra
+
+# User to connect to PostgreSQL server
+# pgsqlUser=georchestra
+
+# Password to connect to PostgreSQL server
+# pgsqlPassword=georchestra
+
+####################################
+#  Datafeeder specific properties  #
+####################################
+
+# pgsqlSchema=datafeeder
+
+# maximum size allowed for uploaded files. (e.g. 128MB, GB can't be used, only KB or MB)
+file-upload.max-file-size=50MB
+# maximum size allowed for multipart/form-data requests (e.g. 128MB, GB can't be used, only KB or MB)
+file-upload.max-request-size=100MB
+# size threshold after which files will be written to disk.
+file-upload.file-size-threshold=1MB
+# directory location where files will be stored by the servlet container once the request exceeds the {@link #fileSizeThreshold}
+file-upload.temporary-location=${java.io.tmpdir}/datafeeder/tmp
+# directory location where files will be stored.
+file-upload.persistent-location=${java.io.tmpdir}/datafeeder/uploads
+
+datafeeder.publishing.geoserver.api-url=http://localhost:8080/geoserver/rest
+datafeeder.publishing.geoserver.public-url=${scheme}://${domainName}/geoserver
+
+datafeeder.publishing.geonetwork.api-url=http://localhost:8081/geonetwork
+datafeeder.publishing.geonetwork.public-url=${scheme}://${domainName}/geonetwork
+
+# GeoTools DataStore connection params used inside datafeeder when importing
+# uploaded datasets to the target store
+datafeeder.publishing.backend.local.dbtype=postgis
+datafeeder.publishing.backend.local.host=localhost
+datafeeder.publishing.backend.local.port=5432
+datafeeder.publishing.backend.local.database=datafeeder
+datafeeder.publishing.backend.local.schema=public
+datafeeder.publishing.backend.local.user=postgres
+datafeeder.publishing.backend.local.passwd=postgres
+datafeeder.publishing.backend.local.preparedStatements=true
+
+# GeoTools DataStore connection params to be used when configuring a GeoServer
+# datastore to access the imported datasets
+datafeeder.publishing.backend.geoserver.dbtype=postgis
+datafeeder.publishing.backend.geoserver.preparedStatements=true
+#<schema> is a placeholder to be replaced by the actual schema computed from the "sec-org" request header
+datafeeder.publishing.backend.geoserver.schema=<schema>
+datafeeder.publishing.backend.geoserver.jndiReferenceName=java:comp/env/jdbc/datafeeder
+#if a JNDI data source is configured in geoserver, uncomment the above line and comment out the following ones 
+#datafeeder.publishing.backend.geoserver.host=localhost
+#datafeeder.publishing.backend.geoserver.port=5432
+#datafeeder.publishing.backend.geoserver.database=datafeeder
+#datafeeder.publishing.backend.geoserver.user=postgres
+#datafeeder.publishing.backend.geoserver.passwd=postgres
+
+# note how to set a property with spaces: property.prefix.[name\ with\ spaces]=value
+datafeeder.publishing.backend.geoserver.[Loose\ bbox]=false
+datafeeder.publishing.backend.geoserver.[Estimated\ extends]=true
+
+

--- a/datafeeder/datafeeder.properties
+++ b/datafeeder/datafeeder.properties
@@ -76,10 +76,44 @@ datafeeder.publishing.backend.geoserver.passwd=${pgsqlPassword}
 datafeeder.publishing.backend.geoserver.[Loose\ bbox]=false
 datafeeder.publishing.backend.geoserver.[Estimated\ extends]=true
 
-logging.level.root=warn
-logging.level.org.springframework=warn
-logging.level.org.hibernate=error
-logging.level.org.georchestra.config.security=debug
-logging.level.org.georchestra.datafeeder=info
-logging.level.org.geoserver.openapi=info
+
+#datafeeder.email.send=true #not used yet
+datafeeder.email.ackTemplate=file:${georchestra.datadir}/datafeeder/templates/analysis-started-email-template.txt
+datafeeder.email.analysisFailedTemplate=file:${georchestra.datadir}/datafeeder/templates/analysis-failed-email-template.txt
+datafeeder.email.publishFailedTemplate=file:${georchestra.datadir}/datafeeder/templates/data-publishing-failed-email-template.txt
+datafeeder.email.publishSuccessTemplate=file:${georchestra.datadir}/datafeeder/templates/data-publishing-succeeded-email-template.txt
+
+administratorEmail=noreply.georchestra.dev@gmail.com
+
+# Configuration for SMTP email sending of application events
+# Datafeeder will send emails to the user when a job is started, finished, or failed,
+# if the spring.mail.* configuration properties are set.
+
+smtpHost=smtp.gmail.com
+smtpPort=587
+smtpUser=noreply.georchestra.dev@gmail.com
+smtpPassword=changeme
+smtpAuth=true
+smtpTLS=true
+
+spring.mail.host=${smtpHost}
+spring.mail.port=${smtpPort}
+spring.mail.username=${smtpUser:}
+spring.mail.password=${smtpPassword:}
+spring.mail.protocol=smtp
+spring.mail.test-connection=${smtpTest:true}
+spring.mail.properties.mail.smtp.auth=${smtpAuth:false}
+spring.mail.properties.mail.smtp.starttls.enable=${smtpTLS:false}
+
+# Example for gmail:
+# make sure 2-step verification is turned off: https://support.google.com/accounts/answer/1064203?hl=en
+# and Allow Less Secure App turnes ON: https://myaccount.google.com/lesssecureapps
+#spring.mail.host=smtp.gmail.com
+#spring.mail.port=587
+#spring.mail.username: noreply.georchestra.dev@gmail.com
+#spring.mail.password: *****
+#spring.mail.protocol: smtp
+#spring.mail.test-connection: true
+#spring.mail.properties.mail.smtp.auth: true
+#spring.mail.properties.mail.smtp.starttls.enable: true
 

--- a/datafeeder/datafeeder.properties
+++ b/datafeeder/datafeeder.properties
@@ -35,7 +35,7 @@ file-upload.persistent-location=${java.io.tmpdir}/datafeeder/uploads
 # select the file to serve as the front-end application configuration
 front-end.config.uri=file:${georchestra.datadir}/datafeeder/frontend-config.json
 
-datafeeder.publishing.geoserver.api-url=http://geoserver:8080/geoserver/rest
+datafeeder.publishing.geoserver.api-url=http://localhost:8280/geoserver/rest
 datafeeder.publishing.geoserver.public-url=${scheme}://${domainName}/geoserver
 # Use this for HTTP basic authentication to geoserver api url:
 #datafeeder.publishing.geoserver.auth.type=basic
@@ -48,7 +48,7 @@ datafeeder.publishing.geoserver.auth.headers.[sec-username]=datafeeder-applicati
 datafeeder.publishing.geoserver.auth.headers.[sec-roles]=ROLE_ADMINISTRATOR
 
 
-datafeeder.publishing.geonetwork.api-url=http://geonetwork:8080/geonetwork
+datafeeder.publishing.geonetwork.api-url=http://localhost:8280/geonetwork
 datafeeder.publishing.geonetwork.public-url=${scheme}://${domainName}/geonetwork
 # Use this for HTTP basic authentication to Geonetwork's api url:
 #datafeeder.publishing.geonetwork.auth.type=basic
@@ -107,18 +107,18 @@ datafeeder.email.analysisFailedTemplate=file:${georchestra.datadir}/datafeeder/t
 datafeeder.email.publishFailedTemplate=file:${georchestra.datadir}/datafeeder/templates/data-publishing-failed-email-template.txt
 datafeeder.email.publishSuccessTemplate=file:${georchestra.datadir}/datafeeder/templates/data-publishing-succeeded-email-template.txt
 
-administratorEmail=noreply.georchestra.dev@gmail.com
+administratorEmail=georchestra@georchestra.mydomain.org
 
 # Configuration for SMTP email sending of application events
 # Datafeeder will send emails to the user when a job is started, finished, or failed,
 # if the spring.mail.* configuration properties are set.
 
-smtpHost=smtp.gmail.com
-smtpPort=587
-smtpUser=noreply.georchestra.dev@gmail.com
-smtpPassword=changeme
-smtpAuth=true
-smtpTLS=true
+smtpHost=localhost
+smtpPort=25
+smtpUser=
+smtpPassword=
+smtpAuth=false
+smtpTLS=false
 
 spring.mail.host=${smtpHost}
 spring.mail.port=${smtpPort}

--- a/datafeeder/frontend-config.json
+++ b/datafeeder/frontend-config.json
@@ -1,0 +1,26 @@
+{
+  "encodings": [
+    {
+      "label": "UTF-8",
+      "value": "UTF-8"
+    },
+    {
+      "label": "ISO-8859-1",
+      "value": "ISO-8859-1"
+    }
+  ],
+  "projections": [
+    {
+      "label": "WGS84",
+      "value": "EPSG:4326"
+    },
+    {
+      "label": "Lambert 93",
+      "value": "EPSG:2154"
+    },
+    {
+      "label": "Web Mercator",
+      "value": "EPSG:3857"
+    }
+  ]
+}

--- a/datafeeder/frontend-config.json
+++ b/datafeeder/frontend-config.json
@@ -23,5 +23,5 @@
       "value": "EPSG:3857"
     }
   ],
-  "thesaurusUrl": "https://georchestra-127-0-1-1.traefik.me/geonetwork/srv/api/registries/vocabularies/search?type=CONTAINS&thesaurus=external.theme.httpinspireeceuropaeutheme-theme&rows=200&q=${q}&uri=**&lang=fre"
+  "thesaurusUrl": "https://georchestra.mydomain.org/geonetwork/srv/api/registries/vocabularies/search?type=CONTAINS&thesaurus=external.theme.httpinspireeceuropaeutheme-theme&rows=200&q=${q}&uri=**&lang=fre"
 }

--- a/datafeeder/frontend-config.json
+++ b/datafeeder/frontend-config.json
@@ -22,5 +22,6 @@
       "label": "Web Mercator",
       "value": "EPSG:3857"
     }
-  ]
+  ],
+  "thesaurusUrl": "https://georchestra-127-0-1-1.traefik.me/geonetwork/srv/api/registries/vocabularies/search?type=CONTAINS&thesaurus=external.theme.httpinspireeceuropaeutheme-theme&rows=200&q=${q}&uri=**&lang=fre"
 }

--- a/datafeeder/frontend-config.json
+++ b/datafeeder/frontend-config.json
@@ -23,5 +23,5 @@
       "value": "EPSG:3857"
     }
   ],
-  "thesaurusUrl": "https://georchestra.mydomain.org/geonetwork/srv/api/registries/vocabularies/search?type=CONTAINS&thesaurus=external.theme.httpinspireeceuropaeutheme-theme&rows=200&q=${q}&uri=**&lang=fre"
+  "thesaurusUrl": "https://georchestra.mydomain.org/geonetwork/srv/api/registries/vocabularies/search?type=CONTAINS&thesaurus=external.theme.inspire-theme&rows=200&q=${q}&uri=**&lang=fre"
 }

--- a/datafeeder/metadata_template.xml
+++ b/datafeeder/metadata_template.xml
@@ -1,0 +1,303 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+  xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:srv="http://www.isotc211.org/2005/srv"
+  xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gts="http://www.isotc211.org/2005/gts"
+  xmlns:gsr="http://www.isotc211.org/2005/gsr" xmlns:gmi="http://www.isotc211.org/2005/gmi"
+  xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+	<!-- https://sdi.eea.europa.eu/catalogue/srv/api/records/38ee29b5-70b1-4431-abf6-7c1aa3c50515/formatters/xml?approved=true -->
+  <gmd:fileIdentifier>
+    <gco:CharacterString>38ee29b5-70b1-4431-abf6-7c1aa3c50515</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language>
+    <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng" />
+  </gmd:language>
+  <gmd:characterSet>
+    <gmd:MD_CharacterSetCode
+      codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+  </gmd:characterSet>
+  <gmd:hierarchyLevel>
+    <gmd:MD_ScopeCode
+      codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset" />
+  </gmd:hierarchyLevel>
+  <gmd:contact xlink:title="Replaced by XSLT" xlink:role="template" />
+  <gmd:dateStamp>
+    <gco:DateTime>1970-01-01T00:00:00</gco:DateTime>
+  </gmd:dateStamp>
+  <gmd:metadataStandardName>
+    <gco:CharacterString>ISO 19115/19139</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:metadataStandardVersion>
+    <gco:CharacterString>1.0</gco:CharacterString>
+  </gmd:metadataStandardVersion>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+          <!-- template -->
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title>
+            <gco:CharacterString>Template</gco:CharacterString>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>1970-01-01</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode
+                  codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                  codeListValue="creation" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>1970-01-01</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode
+                  codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                  codeListValue="publication" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString></gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmd:identifier>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract>
+        <gco:CharacterString>Template abstract</gco:CharacterString>
+      </gmd:abstract>
+      <gmd:pointOfContact xlink:title="Replaced by XSLT" xlink:role="template" />
+      <gmd:resourceMaintenance>
+        <gmd:MD_MaintenanceInformation>
+          <gmd:maintenanceAndUpdateFrequency>
+            <gmd:MD_MaintenanceFrequencyCode
+              codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_MaintenanceFrequencyCode"
+              codeListValue="asNeeded" />
+          </gmd:maintenanceAndUpdateFrequency>
+        </gmd:MD_MaintenanceInformation>
+      </gmd:resourceMaintenance>
+      <gmd:graphicOverview>
+        <gmd:MD_BrowseGraphic>
+          <gmd:fileName>
+            <gco:CharacterString></gco:CharacterString>
+          </gmd:fileName>
+        </gmd:MD_BrowseGraphic>
+      </gmd:graphicOverview>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>Template</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode
+              codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_KeywordTypeCode"
+              codeListValue="theme" />
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gmx:Anchor xlink:href="https://www.eea.europa.eu/themes">EEA topics</gmx:Anchor>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2020-09-24</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode
+                      codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                      codeListValue="publication" />
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor
+                      xlink:href="https://sdi.eea.europa.eu/catalogue/srv/api/registries/vocabularies/external.theme.eea-topics">geonetwork.thesaurus.external.theme.eea-topics</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:resourceConstraints>
+        <gmd:MD_Constraints />
+      </gmd:resourceConstraints>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:accessConstraints>
+            <gmd:MD_RestrictionCode
+              codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode"
+              codeListValue="otherRestrictions" />
+          </gmd:accessConstraints>
+          <gmd:otherConstraints>
+            <gmx:Anchor
+              xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">No limitations to public access</gmx:Anchor>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode
+              codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode"
+              codeListValue="license" />
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gco:CharacterString>Template</gco:CharacterString>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+      <gmd:aggregationInfo>
+        <gmd:MD_AggregateInformation>
+          <gmd:aggregateDataSetIdentifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gmx:Anchor
+                  xlink:href="https://sdi.eea.europa.eu/catalogue/srv/eng/catalog.search#/metadata/4e2c9bcd-9ba5-465f-abaa-2b2f28fc68a5"
+                  xlink:title="Urban Waste Water Treatment Directive  Treatment plants reported under UWWTD data call 2017 - PUBLIC VERSION - Oct. 2019">4e2c9bcd-9ba5-465f-abaa-2b2f28fc68a5</gmx:Anchor>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmd:aggregateDataSetIdentifier>
+          <gmd:associationType>
+            <gmd:DS_AssociationTypeCode
+              codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#DS_AssociationTypeCode"
+              codeListValue="revisionOf" />
+          </gmd:associationType>
+        </gmd:MD_AggregateInformation>
+      </gmd:aggregationInfo>
+      <gmd:spatialRepresentationType>
+        <gmd:MD_SpatialRepresentationTypeCode
+          codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_SpatialRepresentationTypeCode"
+          codeListValue="vector" />
+      </gmd:spatialRepresentationType>
+      <gmd:spatialResolution>
+        <gmd:MD_Resolution>
+          <gmd:distance>
+            <gco:Distance uom="m">100</gco:Distance>
+          </gmd:distance>
+        </gmd:MD_Resolution>
+      </gmd:spatialResolution>
+      <gmd:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng" />
+      </gmd:language>
+      <!-- 
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>environment</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+       -->
+      <gmd:extent>
+        <gmd:EX_Extent>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicBoundingBox>
+              <gmd:westBoundLongitude>
+                <gco:Decimal>0</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>0</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>0</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>0</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+          </gmd:geographicElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:distributionInfo>
+    <gmd:MD_Distribution>
+      <gmd:distributionFormat xmlns:che="http://www.geocat.ch/2008/che">
+        <gmd:MD_Format>
+          <gmd:name>
+            <gco:CharacterString>SHP</gco:CharacterString>
+          </gmd:name>
+          <gmd:version>
+            <gco:CharacterString>1</gco:CharacterString>
+          </gmd:version>
+        </gmd:MD_Format>
+      </gmd:distributionFormat>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <!-- to be filled by XSL -->
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+    </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+  <gmd:dataQualityInfo>
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeListValue="dataset"
+              codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ScopeCode" />
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:report>
+        <gmd:DQ_DomainConsistency>
+          <gmd:result>
+            <gmd:DQ_ConformanceResult>
+              <gmd:specification>
+                <gmd:CI_Citation>
+                  <gmd:title>
+                    <gco:CharacterString>Commission Regulation (EU) No 1089/2010 of 23 November 2010 implementing
+                      Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of
+                      spatial data sets and services</gco:CharacterString>
+                  </gmd:title>
+                  <gmd:date>
+                    <gmd:CI_Date>
+                      <gmd:date>
+                        <gco:Date>2010-12-08</gco:Date>
+                      </gmd:date>
+                      <gmd:dateType>
+                        <gmd:CI_DateTypeCode
+                          codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                          codeListValue="publication" />
+                      </gmd:dateType>
+                    </gmd:CI_Date>
+                  </gmd:date>
+                </gmd:CI_Citation>
+              </gmd:specification>
+              <gmd:explanation>
+                <gco:CharacterString>See the referenced specification</gco:CharacterString>
+              </gmd:explanation>
+              <gmd:pass gco:nilReason="unknown" />
+            </gmd:DQ_ConformanceResult>
+          </gmd:result>
+        </gmd:DQ_DomainConsistency>
+      </gmd:report>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement>
+            <gco:CharacterString>Template Lineage</gco:CharacterString>
+          </gmd:statement>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
+</gmd:MD_Metadata>

--- a/datafeeder/metadata_transform.xsl
+++ b/datafeeder/metadata_transform.xsl
@@ -1,0 +1,340 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:exsl="http://exslt.org/common" extension-element-prefixes="exsl" xmlns:gmd="http://www.isotc211.org/2005/gmd"
+  xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:srv="http://www.isotc211.org/2005/srv"
+  xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gts="http://www.isotc211.org/2005/gts"
+  xmlns:gsr="http://www.isotc211.org/2005/gsr" xmlns:gmi="http://www.isotc211.org/2005/gmi"
+  xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd"
+  exclude-result-prefixes="gmd srv gco">
+<!-- 
+Default template to apply MetadataRecordProperties.java properties to a record template adhering to http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd
+ -->
+  <xsl:strip-space elements="*" xmlns="http://www.isotc211.org/2005/gmd" />
+  <xsl:output indent="yes" standalone="yes" />
+
+  <!-- Whole document used as xsl parameter, see sample_md_properties.xml for an example of its contents -->
+  <xsl:param name="props" />
+
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="gmd:fileIdentifier/gco:CharacterString">
+    <gco:CharacterString>
+      <xsl:value-of select="$props//metadataId" />
+    </gco:CharacterString>
+  </xsl:template>
+
+  <xsl:template match="gmd:language/gmd:LanguageCode/@codeListValue">
+    <xsl:attribute name="codeListValue">
+      <xsl:value-of select="$props//metadataLanguage" />
+    </xsl:attribute>
+  </xsl:template>
+
+  <xsl:template match="gmd:dateStamp">
+    <gmd:dateStamp>
+      <gco:DateTime>
+        <xsl:value-of select="$props//metadataTimestamp" />
+      </gco:DateTime>
+    </gmd:dateStamp>
+  </xsl:template>
+
+  <xsl:template
+    match="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString">
+    <gco:CharacterString>
+      <xsl:value-of select="$props//title" />
+    </gco:CharacterString>
+  </xsl:template>
+
+  <xsl:template match="//gmd:MD_DataIdentification/gmd:abstract/gco:CharacterString">
+    <gco:CharacterString>
+      <xsl:value-of select="$props//abstract" />
+    </gco:CharacterString>
+  </xsl:template>
+
+  <xsl:template match="//gmd:MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords">
+    <gmd:MD_Keywords>
+      <xsl:for-each select="$props//keywords//keyword">
+        <gmd:keyword>
+          <gco:CharacterString>
+            <xsl:value-of select="." />
+          </gco:CharacterString>
+        </gmd:keyword>
+      </xsl:for-each>
+      <gmd:type>
+        <gmd:MD_KeywordTypeCode
+          codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_KeywordTypeCode"
+          codeListValue="theme" />
+      </gmd:type>
+      <gmd:thesaurusName>
+        <gmd:CI_Citation>
+          <gmd:title>
+            <gco:CharacterString>GEMET - INSPIRE themes, version 1.0</gco:CharacterString>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2008-06-01</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode
+                  codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                  codeListValue="publication" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gmx:Anchor
+                  xlink:href="https://sdi.eea.europa.eu/catalogue/srv/api/registries/vocabularies/external.theme.httpinspireeceuropaeutheme-theme">geonetwork.thesaurus.external.theme.httpinspireeceuropaeutheme-theme</gmx:Anchor>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmd:identifier>
+        </gmd:CI_Citation>
+      </gmd:thesaurusName>
+    </gmd:MD_Keywords>
+  </xsl:template>
+
+  <xsl:template
+    match="//gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:date[1]/gmd:CI_Date/gmd:date/gco:Date">
+    <gco:Date>
+      <xsl:value-of select="$props//creationDate" />
+    </gco:Date>
+  </xsl:template>
+  <xsl:template
+    match="//gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:date[2]/gmd:CI_Date/gmd:date/gco:Date">
+    <gco:Date>
+      <xsl:value-of select="$props//metadataPublicationDate" />
+    </gco:Date>
+  </xsl:template>
+
+  <xsl:template
+    match="//gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code/gco:CharacterString">
+    <gco:CharacterString>
+      <xsl:value-of select="$props//dataIdentifier" />
+    </gco:CharacterString>
+  </xsl:template>
+
+
+  <xsl:template
+    match="//gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox">
+    <gmd:EX_GeographicBoundingBox>
+      <gmd:westBoundLongitude>
+        <gco:Decimal>
+          <xsl:value-of select="$props//westBoundLongitude" />
+        </gco:Decimal>
+      </gmd:westBoundLongitude>
+      <gmd:eastBoundLongitude>
+        <gco:Decimal>
+          <xsl:value-of select="$props//eastBoundLongitude" />
+        </gco:Decimal>
+      </gmd:eastBoundLongitude>
+      <gmd:southBoundLatitude>
+        <gco:Decimal>
+          <xsl:value-of select="$props//southBoundLatitude" />
+        </gco:Decimal>
+      </gmd:southBoundLatitude>
+      <gmd:northBoundLatitude>
+        <gco:Decimal>
+          <xsl:value-of select="$props//northBoundLatitude" />
+        </gco:Decimal>
+      </gmd:northBoundLatitude>
+    </gmd:EX_GeographicBoundingBox>
+  </xsl:template>
+
+  <xsl:template
+    match="//gmd:MD_DataIdentification/gmd:spatialRepresentationType/gmd:MD_SpatialRepresentationTypeCode/@codeListValue">
+    <xsl:attribute name="codeListValue">
+      <xsl:value-of select="$props//spatialRepresentation" />
+    </xsl:attribute>
+  </xsl:template>
+
+  <xsl:template match="//gmd:MD_DataIdentification/gmd:spatialResolution">
+    <gmd:spatialResolution>
+      <gmd:MD_Resolution>
+        <gmd:equivalentScale>
+          <gmd:MD_RepresentativeFraction>
+            <gmd:denominator>
+              <gco:Integer>
+                <xsl:value-of select="$props//spatialResolution" />
+              </gco:Integer>
+            </gmd:denominator>
+          </gmd:MD_RepresentativeFraction>
+        </gmd:equivalentScale>
+      </gmd:MD_Resolution>
+    </gmd:spatialResolution>
+  </xsl:template>
+
+  <xsl:template match="//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact">
+    <gmd:pointOfContact>
+      <xsl:call-template name="contactInfo">
+        <xsl:with-param name="individualName" select="$props//datasetResponsibleParty//individualName" />
+        <xsl:with-param name="organizationName"
+          select="$props//datasetResponsibleParty//organizationName" />
+        <xsl:with-param name="deliveryPoint"
+          select="$props//datasetResponsibleParty//address//deliveryPoint" />
+        <xsl:with-param name="city" select="$props//datasetResponsibleParty//address//city" />
+        <xsl:with-param name="postalCode" select="$props//datasetResponsibleParty//address//postalCode" />
+        <xsl:with-param name="country" select="$props//datasetResponsibleParty//address//country" />
+        <xsl:with-param name="email" select="$props//datasetResponsibleParty//email" />
+        <xsl:with-param name="protocol" select="$props//datasetResponsibleParty//protocol" />
+        <xsl:with-param name="linkage" select="$props//datasetResponsibleParty//linkage" />
+      </xsl:call-template>
+    </gmd:pointOfContact>
+  </xsl:template>
+
+  <xsl:template match="//gmd:contact">
+    <gmd:contact>
+      <xsl:call-template name="contactInfo">
+        <xsl:with-param name="individualName" select="$props//metadataResponsibleParty//individualName" />
+        <xsl:with-param name="organizationName"
+          select="$props//datasetResponsibleParty//organizationName" />
+        <xsl:with-param name="deliveryPoint"
+          select="$props//datasetResponsibleParty//address//deliveryPoint" />
+        <xsl:with-param name="city" select="$props//datasetResponsibleParty//address//city" />
+        <xsl:with-param name="postalCode" select="$props//datasetResponsibleParty//address//postalCode" />
+        <xsl:with-param name="country" select="$props//datasetResponsibleParty//address//country" />
+        <xsl:with-param name="email" select="$props//datasetResponsibleParty//email" />
+        <xsl:with-param name="protocol" select="$props//datasetResponsibleParty//protocol" />
+        <xsl:with-param name="linkage" select="$props//datasetResponsibleParty//linkage" />
+      </xsl:call-template>
+    </gmd:contact>
+  </xsl:template>
+
+  <xsl:template
+    match="//gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:lineage/gmd:LI_Lineage/gmd:statement/gco:CharacterString">
+    <gco:CharacterString>
+      <xsl:value-of select="$props//lineage" />
+    </gco:CharacterString>
+  </xsl:template>
+
+  <xsl:template match="//gmd:hierarchyLevel/gmd:MD_ScopeCode">
+    <gmd:MD_ScopeCode
+      codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ScopeCode" codeListValue="series" />
+  </xsl:template>
+
+  <xsl:template
+    match="//gmd:distributionInfo//gmd:MD_Distribution//gmd:transferOptions//gmd:MD_DigitalTransferOptions">
+    <gmd:MD_DigitalTransferOptions>
+      <xsl:for-each select="$props//onlineResources//onlineResource">
+        <gmd:onLine>
+          <xsl:call-template name="onlineResource">
+            <xsl:with-param name="linkage" select="linkage" />
+            <xsl:with-param name="protocol" select="protocol" />
+            <xsl:with-param name="name" select="name" />
+            <xsl:with-param name="description" select="description" />
+          </xsl:call-template>
+        </gmd:onLine>
+      </xsl:for-each>
+    </gmd:MD_DigitalTransferOptions>
+  </xsl:template>
+
+  <xsl:template match="//gmd:characterSet//gmd:MD_CharacterSetCode/@codeListValue">
+    <xsl:attribute name="codeListValue">
+      <xsl:value-of select="$props//charsetEncoding" />
+    </xsl:attribute>
+  </xsl:template>
+
+  <xsl:template
+    match="gmd:referenceSystemInfo//gmd:MD_ReferenceSystem//gmd:referenceSystemIdentifier//gmd:RS_Identifier/gmd:code">
+    <gmd:code>
+      <gco:CharacterString>
+        <xsl:value-of select="$props//coordinateReferenceSystem" />
+      </gco:CharacterString>
+    </gmd:code>
+  </xsl:template>
+   
+
+  <!-- Creates a CI_ResponsibleParty -->
+  <xsl:template name="contactInfo">
+    <xsl:param name="individualName" />
+    <xsl:param name="organizationName" />
+    <xsl:param name="deliveryPoint" />
+    <xsl:param name="city" />
+    <xsl:param name="postalCode" />
+    <xsl:param name="country" />
+    <xsl:param name="email" />
+    <xsl:param name="protocol" />
+    <xsl:param name="linkage" />
+    <gmd:CI_ResponsibleParty>
+      <gmd:individualName>
+        <gco:CharacterString><xsl:value-of select="$individualName" /></gco:CharacterString>
+      </gmd:individualName>
+      <gmd:organisationName>
+        <gco:CharacterString><xsl:value-of select="$organizationName" /></gco:CharacterString>
+      </gmd:organisationName>
+      <gmd:contactInfo>
+        <gmd:CI_Contact>
+          <gmd:address>
+            <gmd:CI_Address>
+              <gmd:deliveryPoint>
+                <gco:CharacterString><xsl:value-of select="$deliveryPoint" /></gco:CharacterString>
+              </gmd:deliveryPoint>
+              <gmd:city>
+                <gco:CharacterString><xsl:value-of select="$city" /></gco:CharacterString>
+              </gmd:city>
+              <gmd:postalCode>
+                <gco:CharacterString><xsl:value-of select="$postalCode" /></gco:CharacterString>
+              </gmd:postalCode>
+              <gmd:country>
+                <gco:CharacterString><xsl:value-of select="$country" /></gco:CharacterString>
+              </gmd:country>
+              <gmd:electronicMailAddress>
+                <gco:CharacterString><xsl:value-of select="$email" /></gco:CharacterString>
+              </gmd:electronicMailAddress>
+            </gmd:CI_Address>
+          </gmd:address>
+          <gmd:onlineResource>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>
+                  <xsl:value-of select="$linkage" />
+                </gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString><xsl:value-of select="$protocol" /></gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gco:CharacterString><xsl:value-of select="$organizationName" /></gco:CharacterString>
+              </gmd:name>
+            </gmd:CI_OnlineResource>
+          </gmd:onlineResource>
+          <gmd:contactInstructions />
+        </gmd:CI_Contact>
+      </gmd:contactInfo>
+      <gmd:role>
+        <gmd:CI_RoleCode
+          codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_RoleCode"
+          codeListValue="pointOfContact" />
+      </gmd:role>
+    </gmd:CI_ResponsibleParty>
+  </xsl:template>
+
+  <!-- creates a CI_OnlineResource with the given parameters -->
+  <xsl:template name="onlineResource">
+    <xsl:param name="linkage" />
+    <xsl:param name="protocol" />
+    <xsl:param name="name" />
+    <xsl:param name="description" />
+    <gmd:CI_OnlineResource>
+      <gmd:linkage>
+        <gmd:URL>
+          <xsl:value-of select="$linkage" />
+        </gmd:URL>
+      </gmd:linkage>
+      <gmd:protocol>
+        <gco:CharacterString><xsl:value-of select="$protocol" /></gco:CharacterString>
+      </gmd:protocol>
+      <gmd:name>
+        <gco:CharacterString><xsl:value-of select="$name" /></gco:CharacterString>
+      </gmd:name>
+      <gmd:description>
+        <gco:CharacterString><xsl:value-of select="$description" /></gco:CharacterString>
+      </gmd:description>
+    </gmd:CI_OnlineResource>
+  </xsl:template>
+</xsl:stylesheet>

--- a/datafeeder/templates/README.md
+++ b/datafeeder/templates/README.md
@@ -1,0 +1,58 @@
+# Email message templates
+
+Message template locations are to be configured in `datafeeder.propeties` using the following properties:
+
+```
+datafeeder.email.ackTemplate=file:${georchestra.datadir}/datafeeder/templates/analysis-started-email-template.txt
+datafeeder.email.analysisFailedTemplate=file:${georchestra.datadir}/datafeeder/templates/analysis-failed-email-template.txt
+datafeeder.email.publishFailedTemplate=file:${georchestra.datadir}/datafeeder/templates/data-publishing-failed-email-template.txt
+datafeeder.email.publishSuccessTemplate=file:${georchestra.datadir}/datafeeder/templates/data-publishing-succeeded-email-template.txt
+```
+
+A message template consists of a number of one-line header parts, followed by the full message body.
+
+Variables on a message template are specified using `${variable-name}` notation, like in the following example:
+
+```
+to: ${user.email}
+cc: ${administratorEmail}
+bcc:
+sender: ${administratorEmail}
+from: Georchestra Importer Application
+subject:
+body:
+
+Dear ${user.name}, 
+....
+```
+
+The following variables are resolved against the job's user, dataset, or publishing attributes:
+
+* `${user.name}`:
+* `${user.lastName}`:
+* `${user.email}`:
+* `${job.id}`:
+* `${job.createdAt}`:
+* `${job.error}`:
+* `${job.analizeStatus}`:
+* `${job.publishStatus}`:
+* `${dataset.name}`:
+* `${dataset.featureCount}`:
+* `${dataset.encoding}`:
+* `${dataset.nativeBounds}`:
+* `${publish.tableName}`:
+* `${publish.layerName}`:
+* `${publish.workspace}`:
+* `${publish.srs}`:
+* `${publish.encoding}`:
+* `${metadata.id}`:
+* `${metadata.title}`:
+* `${metadata.abstract}`:
+* `${metadata.creationDate}`:
+* `${metadata.lineage}`:
+* `${metadata.latLonBoundingBox}`:
+* `${metadata.keywords}`:
+* `${metadata.scale}`:
+
+Additionally, any other <code>${property}</code> will be resolved against the application context 
+(for example, any property specified in `default.properties` or `datafeeder.properties`).

--- a/datafeeder/templates/README.md
+++ b/datafeeder/templates/README.md
@@ -1,6 +1,6 @@
 # Email message templates
 
-Message template locations are to be configured in `datafeeder.propeties` using the following properties:
+Message template locations are to be configured in `datafeeder.properties` using the following properties:
 
 ```
 datafeeder.email.ackTemplate=file:${georchestra.datadir}/datafeeder/templates/analysis-started-email-template.txt
@@ -18,7 +18,7 @@ to: ${user.email}
 cc: ${administratorEmail}
 bcc:
 sender: ${administratorEmail}
-from: Georchestra Importer Application
+from: geOrchestra Importer Application
 subject:
 body:
 

--- a/datafeeder/templates/analysis-failed-email-template.txt
+++ b/datafeeder/templates/analysis-failed-email-template.txt
@@ -1,0 +1,43 @@
+to: ${user.email}
+cc: ${administratorEmail}
+bcc:
+sender: ${administratorEmail}
+from: Georchestra Importer Application
+subject: Problem analyzing your ${dataset.name} dataset
+body:
+
+Dear ${user.name}, 
+
+We're sorry to inform you that a problem occurred during the
+analysis phase for the ${dataset.name} you've uploaded.
+
+Here's the full information:
+
+user.name: ${user.name}
+user.lastName: ${user.lastName}
+user.email: ${user.email}
+job.id: ${job.id}
+job.createdAt: ${job.createdAt}
+job.error: ${job.error}
+job.analizeStatus: ${job.analizeStatus}
+job.publishStatus: ${job.publishStatus}
+dataset.name: ${dataset.name}
+dataset.featureCount: ${dataset.featureCount}
+dataset.encoding: ${dataset.encoding}
+dataset.nativeBounds: ${dataset.nativeBounds}
+publish.tableName: ${publish.tableName}
+publish.layerName: ${publish.layerName}
+publish.workspace: ${publish.workspace}
+publish.srs: ${publish.srs}
+publish.encoding: ${publish.encoding}
+metadata.id: ${metadata.id}
+metadata.title: ${metadata.title}
+metadata.abstract: ${metadata.abstract}
+metadata.creationDate: ${metadata.creationDate}
+metadata.lineage: ${metadata.lineage}
+metadata.latLonBoundingBox: ${metadata.latLonBoundingBox}
+metadata.keywords: ${metadata.keywords}
+metadata.scale: ${metadata.scale}
+
+---
+Sent by ${instanceName}

--- a/datafeeder/templates/analysis-started-email-template.txt
+++ b/datafeeder/templates/analysis-started-email-template.txt
@@ -1,0 +1,40 @@
+to: ${user.email}
+cc: ${administratorEmail}
+bcc:
+sender: ${administratorEmail}
+from: Georchestra Importer Application
+subject: Analysis process started for your ${dataset.name} dataset
+body:
+
+Dear ${user.name}, 
+
+Your ${dataset.name} dataset was received correctly and is currently being analyzed.
+
+user.name: ${user.name}
+user.lastName: ${user.lastName}
+user.email: ${user.email}
+job.id: ${job.id}
+job.createdAt: ${job.createdAt}
+job.error: ${job.error}
+job.analizeStatus: ${job.analizeStatus}
+job.publishStatus: ${job.publishStatus}
+dataset.name: ${dataset.name}
+dataset.featureCount: ${dataset.featureCount}
+dataset.encoding: ${dataset.encoding}
+dataset.nativeBounds: ${dataset.nativeBounds}
+publish.tableName: ${publish.tableName}
+publish.layerName: ${publish.layerName}
+publish.workspace: ${publish.workspace}
+publish.srs: ${publish.srs}
+publish.encoding: ${publish.encoding}
+metadata.id: ${metadata.id}
+metadata.title: ${metadata.title}
+metadata.abstract: ${metadata.abstract}
+metadata.creationDate: ${metadata.creationDate}
+metadata.lineage: ${metadata.lineage}
+metadata.latLonBoundingBox: ${metadata.latLonBoundingBox}
+metadata.keywords: ${metadata.keywords}
+metadata.scale: ${metadata.scale}
+
+---
+Sent by ${instanceName}

--- a/datafeeder/templates/analysis-started-email-template.txt
+++ b/datafeeder/templates/analysis-started-email-template.txt
@@ -2,7 +2,7 @@ to: ${user.email}
 cc: ${administratorEmail}
 bcc:
 sender: ${administratorEmail}
-from: Georchestra Importer Application
+from: geOrchestra Importer Application
 subject: Analysis process started for your ${dataset.name} dataset
 body:
 

--- a/datafeeder/templates/data-publishing-failed-email-template.txt
+++ b/datafeeder/templates/data-publishing-failed-email-template.txt
@@ -1,0 +1,43 @@
+to: ${user.email}
+cc: ${administratorEmail}
+bcc:
+sender: ${administratorEmail}
+from: Georchestra Importer Application
+subject: Publishing process failed for your ${dataset.name} dataset
+body:
+
+Dear ${user.name}, 
+
+We're sorry to inform you that the publcation process for your
+${dataset.name} dataset failed.
+
+Here's the full information:
+
+user.name: ${user.name}
+user.lastName: ${user.lastName}
+user.email: ${user.email}
+job.id: ${job.id}
+job.createdAt: ${job.createdAt}
+job.error: ${job.error}
+job.analizeStatus: ${job.analizeStatus}
+job.publishStatus: ${job.publishStatus}
+dataset.name: ${dataset.name}
+dataset.featureCount: ${dataset.featureCount}
+dataset.encoding: ${dataset.encoding}
+dataset.nativeBounds: ${dataset.nativeBounds}
+publish.tableName: ${publish.tableName}
+publish.layerName: ${publish.layerName}
+publish.workspace: ${publish.workspace}
+publish.srs: ${publish.srs}
+publish.encoding: ${publish.encoding}
+metadata.id: ${metadata.id}
+metadata.title: ${metadata.title}
+metadata.abstract: ${metadata.abstract}
+metadata.creationDate: ${metadata.creationDate}
+metadata.lineage: ${metadata.lineage}
+metadata.latLonBoundingBox: ${metadata.latLonBoundingBox}
+metadata.keywords: ${metadata.keywords}
+metadata.scale: ${metadata.scale}
+
+---
+Sent by ${instanceName}

--- a/datafeeder/templates/data-publishing-succeeded-email-template.txt
+++ b/datafeeder/templates/data-publishing-succeeded-email-template.txt
@@ -1,0 +1,41 @@
+to: ${user.email}
+cc: ${administratorEmail}
+bcc:
+sender: ${administratorEmail}
+from: Georchestra Importer Application
+subject: Your ${dataset.name} dataset has been published
+body:
+
+Dear ${user.name}, 
+
+We're pleased to inform you that your ${dataset.name} dataset
+has been published.
+
+user.name: ${user.name}
+user.lastName: ${user.lastName}
+user.email: ${user.email}
+job.id: ${job.id}
+job.createdAt: ${job.createdAt}
+job.error: ${job.error}
+job.analizeStatus: ${job.analizeStatus}
+job.publishStatus: ${job.publishStatus}
+dataset.name: ${dataset.name}
+dataset.featureCount: ${dataset.featureCount}
+dataset.encoding: ${dataset.encoding}
+dataset.nativeBounds: ${dataset.nativeBounds}
+publish.tableName: ${publish.tableName}
+publish.layerName: ${publish.layerName}
+publish.workspace: ${publish.workspace}
+publish.srs: ${publish.srs}
+publish.encoding: ${publish.encoding}
+metadata.id: ${metadata.id}
+metadata.title: ${metadata.title}
+metadata.abstract: ${metadata.abstract}
+metadata.creationDate: ${metadata.creationDate}
+metadata.lineage: ${metadata.lineage}
+metadata.latLonBoundingBox: ${metadata.latLonBoundingBox}
+metadata.keywords: ${metadata.keywords}
+metadata.scale: ${metadata.scale}
+
+---
+Sent by ${instanceName}

--- a/security-proxy/headers-mapping.properties
+++ b/security-proxy/headers-mapping.properties
@@ -4,7 +4,7 @@
 # 
 # Header names with no prefix (default headers) apply to all proxified services (e.g. sec-email=mail).
 # Header names prefixed with a service name as defined in targets-mapping.properties
-# complement the default headers when hitting a specific proxified servicei. for example:
+# complement the default headers when hitting a specific proxified service. for example:
 # analytics.sec-org-address=org.seeAlso.postalAddress
 # will also add the `sec-org-address` with the user organization's postal address as value
 # to requests hitting the analytics service.
@@ -25,7 +25,7 @@
 # sec-org=org.cn
 # sec-orgname=org.o
 #
-# Authenticated user attribtues:
+# Authenticated user attributes:
 # ==============================
 #uid
 #givenName
@@ -39,7 +39,7 @@
 #objectClass
 #knowledgeInformation
 #
-# Authenticated user's manager attribtues
+# Authenticated user's manager attributes
 # =======================================
 #manager.uid
 #manager.mail
@@ -49,7 +49,7 @@
 #manager.cn
 #manager.objectClass
 #
-# Authenticated user's organization attribtues
+# Authenticated user's organization attributes
 # ============================================
 #org.cn
 #org.ou
@@ -58,7 +58,7 @@
 #org.description
 #org.objectClass
 #
-# Authenticated user's organization extended attribtues
+# Authenticated user's organization extended attributes
 # =====================================================
 #org.seeAlso.o
 #org.seeAlso.labeledURI

--- a/security-proxy/headers-mapping.properties
+++ b/security-proxy/headers-mapping.properties
@@ -1,15 +1,91 @@
-# Keys are additional headers sent by the security-proxy,
-# mapped onto user's LDAP attributes.
+# Keys are additional headers sent by the security-proxy, mapped onto user's LDAP attributes:
+# Additionally, LDAP objects related to the authenticated user are accessible through
+# prefixed attribute names `manager.`, `org.`, and `org.seeAlso.`
+# 
+# Header names with no prefix (default headers) apply to all proxified services (e.g. sec-email=mail).
+# Header names prefixed with a service name as defined in targets-mapping.properties
+# complement the default headers when hitting a specific proxified servicei. for example:
+# analytics.sec-org-address=org.seeAlso.postalAddress
+# will also add the `sec-org-address` with the user organization's postal address as value
+# to requests hitting the analytics service.
+# 
+# Base64 header value encoding:
+# ============================
+# Due to HTTP headers being ISO-8859-1 encoded by spec, header values that can potentially have
+# characters outside that encoding can be configured to be base64-encoded. If so, the target service
+# must know how to decode them. For example:
+# sec-orgname=base64:org.o
+# will override the default sec-orgname header with a base64 encoded value.
 #
-# The following headers are already provided by the proxy,
-# regardless of this file's content:
-#  * sec-username
-#  * sec-roles
-#  * sec-org
-#  * sec-orgname
-#  * sec-proxy
+# Embedded headers:
+# =================
+# The following header mappings apply to all requests with no need of being configured in this file:
+# sec-username=uid
+# sec-roles (no specific mapping, contains the list of roles separated by `;`)
+# sec-org=org.cn
+# sec-orgname=org.o
 #
+# Authenticated user attribtues:
+# ==============================
+#uid
+#givenName
+#sn
+#cn
+#telephoneNumber
+#mail
+#postalAddress
+#description
+#title
+#objectClass
+#knowledgeInformation
+#
+# Authenticated user's manager attribtues
+# =======================================
+#manager.uid
+#manager.mail
+#manager.givenName
+#manager.description
+#manager.sn
+#manager.cn
+#manager.objectClass
+#
+# Authenticated user's organization attribtues
+# ============================================
+#org.cn
+#org.ou
+#org.o
+#org.member
+#org.description
+#org.objectClass
+#
+# Authenticated user's organization extended attribtues
+# =====================================================
+#org.seeAlso.o
+#org.seeAlso.labeledURI
+#org.seeAlso.businessCategory
+#org.seeAlso.postalAddress
+#org.seeAlso.description
+#org.seeAlso.knowledgeInformation
+#org.seeAlso.objectClass
+
 sec-email=mail
 sec-firstname=givenName
 sec-lastname=sn
 sec-tel=telephoneNumber
+
+# datafeeder service specific headers:
+datafeeder.sec-firstname=base64:givenName
+datafeeder.sec-lastname=base64:sn
+datafeeder.sec-tel=base64:telephoneNumber
+datafeeder.sec-email=mail
+datafeeder.sec-address=base64:postalAddress
+datafeeder.sec-title=base64:title
+datafeeder.sec-notes=base64:knowledgeInformation
+datafeeder.sec-orgname=base64:org.o
+datafeeder.sec-org-linkage=base64:org.seeAlso.labeledURI
+datafeeder.sec-org-address:base64:org.seeAlso.postalAddress
+datafeeder.sec-org-category:base64:org.seeAlso.businessCategory
+datafeeder.sec-org-description:base64:org.seeAlso.description
+datafeeder.sec-org-notes:base64:org.seeAlso.knowledgeInformation
+
+

--- a/security-proxy/security-mappings.xml
+++ b/security-proxy/security-mappings.xml
@@ -30,4 +30,5 @@
   <intercept-url pattern="/testPage" access="IS_AUTHENTICATED_FULLY" />
   <intercept-url pattern=".*/ogcproxy/.*" access="ROLE_NO_ONE" />
   <intercept-url pattern=".*" access="IS_AUTHENTICATED_ANONYMOUSLY,ROLE_USER,ROLE_GN_EDITOR,ROLE_GN_REVIEWER,ROLE_GN_ADMIN,ROLE_ADMINISTRATOR,ROLE_SUPERUSER,ROLE_ORGADMIN" />
+  <intercept-url pattern="/datafeeder/.*" access="IS_AUTHENTICATED_ANONYMOUSLY,ROLE_USER,ROLE_GN_EDITOR,ROLE_GN_REVIEWER,ROLE_GN_ADMIN,ROLE_ADMINISTRATOR,ROLE_SUPERUSER,ROLE_ORGADMIN" />
 </http>

--- a/security-proxy/security-mappings.xml
+++ b/security-proxy/security-mappings.xml
@@ -30,5 +30,5 @@
   <intercept-url pattern="/testPage" access="IS_AUTHENTICATED_FULLY" />
   <intercept-url pattern=".*/ogcproxy/.*" access="ROLE_NO_ONE" />
   <intercept-url pattern=".*" access="IS_AUTHENTICATED_ANONYMOUSLY,ROLE_USER,ROLE_GN_EDITOR,ROLE_GN_REVIEWER,ROLE_GN_ADMIN,ROLE_ADMINISTRATOR,ROLE_SUPERUSER,ROLE_ORGADMIN" />
-  <intercept-url pattern="/datafeeder/.*" access="IS_AUTHENTICATED_ANONYMOUSLY,ROLE_USER,ROLE_GN_EDITOR,ROLE_GN_REVIEWER,ROLE_GN_ADMIN,ROLE_ADMINISTRATOR,ROLE_SUPERUSER,ROLE_ORGADMIN" />
+  <intercept-url pattern="/datafeeder/.*" access="IS_AUTHENTICATED_FULLY" />
 </http>

--- a/security-proxy/targets-mapping.properties
+++ b/security-proxy/targets-mapping.properties
@@ -7,5 +7,5 @@ geoserver=http://localhost:8380/geoserver/
 header=http://localhost:8280/header/
 mapfishapp=http://localhost:8280/mapfishapp/
 mapstore=http://localhost:8280/mapstore/
-datafeeder=http://localhost:8080/datafeeder/
+datafeeder=http://localhost:8480/datafeeder/
 import=http://localhost:8280/import/

--- a/security-proxy/targets-mapping.properties
+++ b/security-proxy/targets-mapping.properties
@@ -7,3 +7,4 @@ geoserver=http://localhost:8380/geoserver/
 header=http://localhost:8280/header/
 mapfishapp=http://localhost:8280/mapfishapp/
 mapstore=http://localhost:8280/mapstore/
+datafeeder=http://localhost:8280/datafeeder/

--- a/security-proxy/targets-mapping.properties
+++ b/security-proxy/targets-mapping.properties
@@ -7,5 +7,5 @@ geoserver=http://localhost:8380/geoserver/
 header=http://localhost:8280/header/
 mapfishapp=http://localhost:8280/mapfishapp/
 mapstore=http://localhost:8280/mapstore/
-datafeeder=http://localhost:8280/datafeeder/
+datafeeder=http://localhost:8080/datafeeder/
 import=http://localhost:8280/import/

--- a/security-proxy/targets-mapping.properties
+++ b/security-proxy/targets-mapping.properties
@@ -8,3 +8,4 @@ header=http://localhost:8280/header/
 mapfishapp=http://localhost:8280/mapfishapp/
 mapstore=http://localhost:8280/mapstore/
 datafeeder=http://localhost:8280/datafeeder/
+import=http://localhost:8280/import/


### PR DESCRIPTION
The original workflow would be to modify the master branch first prior to merge into docker-master, but since the docker branch was used for the development, we now need to take back the current state of docker-master into master.

Tests: untested yet.

Note: datafeeder is configured to send its logs to stdout / stderr, it's up to the administrator who will deploy it to configure systemd or anything else the appropriate way, e.g. using the following directives in a potential service unit file:

```
StandardOutput=append:/var/log/wherever/mylogs.log
StandardError=append:/var/log/wherever/mylogs.log
```

Managing systemd services isn't probably into this repository's scope.
