### PR TITLE
syncRolesFilter set to EL_* for backward compat

### DIFF
--- a/geonetwork/geonetwork.properties
+++ b/geonetwork/geonetwork.properties
@@ -33,7 +33,7 @@ geonetwork.syncMode=orgs
 # If using 'roles' sync mode, a Java regular expression can be used to filter
 # which Georchestra roles are to be mapped to GeoNetwork groups. Only those role names
 # that march the regular expression will be mapped.
-geonetwork.syncRolesFilter=GN_(.*)
+geonetwork.syncRolesFilter=EL_(.*)
 
 # Map geOrchestra user role names to GeoNetwork user profiles.
 # Available GN profile names are:


### PR DESCRIPTION
Following #221, syncRolesFilter is set to EL_* for backward compat with [previous settings](https://github.com/georchestra/datadir/blob/docker-18.06/geonetwork/geonetwork.properties#L40) when `geonetwork.syncMode` is set `roles` (which is **not** the default).

