### PR TITLE
[mapstore] update localConfig.json for dashboards/geostories/homepage integration

### DIFF
--- a/mapstore/configs/localConfig.json
+++ b/mapstore/configs/localConfig.json
@@ -278,6 +278,9 @@
         }
       }
     },
+    "miscSettings": {
+      "homePath": "/home"
+    },
     "plugins": {
         "mobile": ["Header", {
                 "name": "Map",
@@ -376,7 +379,7 @@
                     }
                 }
             }, "Login",
-            "OmniBar", "BurgerMenu", "Expander", {
+            "OmniBar", "BurgerMenu", "Home", "Expander", {
               "name": "Cookie",
               "cfg": {
                 "externalCookieUrl": "https://docs.georchestra.geo-solutions.it/en/latest/mapstore/index.html",
@@ -779,52 +782,241 @@
           "FeedbackMask"
         ],
         "common": [],
-        "maps": [
-          "Login",
-          {
-            "name": "Maps",
-            "cfg": {
-              "mapsOptions": {
-                "start": 0,
-                "limit": 12
-              },
-              "fluid": true
-            }
-          },
-          "MapSearch",
-          "CreateNewMap",
-          "FeaturedMaps"],
-        "admin": [{
+      "maps": [
+        "Login",
+        "HomeDescription", "Fork",
+        "MapSearch",
+        "CreateNewMap",
+        "FeaturedMaps", "ContentTabs",
+        {
           "name": "Header",
-            "cfg": {
-              "page": "msadmin"
+          "cfg": {
+            "page": "mapstore-home"
+          }
+        },
+        {
+          "name": "Maps",
+          "cfg": {
+            "mapsOptions": {
+              "start": 0,
+              "limit": 12
+            },
+            "fluid": true
+          }
+        },
+        {
+          "name": "Dashboards",
+          "cfg": {
+            "mapsOptions": {
+              "start": 0,
+              "limit": 12
+            },
+            "fluid": true
+          }
+        },
+        {
+          "name": "GeoStories",
+          "cfg": {
+            "mapsOptions": {
+              "start": 0,
+              "limit": 12
+            },
+            "fluid": true
+          }
+        },
+        {
+          "name": "Contexts",
+          "cfg": {
+            "mapsOptions": {
+              "start": 0,
+              "limit": 12
+            },
+            "fluid": true
+          }
+        }],
+      "dashboard": [{
+        "name": "OmniBar",
+        "cfg": {
+          "containerPosition": "header",
+          "className": "navbar shadow navbar-home"
+        }
+      }, "Login", "Language", "NavMenu", "DashboardSave", "DashboardSaveAs", "Attribution", "Home", {
+        "name": "Share",
+        "cfg": {
+          "showAPI": false,
+          "advancedSettings": false,
+          "shareUrlRegex": "(h[^#]*)#\\/dashboard\\/([A-Za-z0-9]*)",
+          "shareUrlReplaceString": "$1dashboard-embedded.html#/$2",
+          "embedOptions": {
+            "showTOCToggle": false,
+            "showConnectionsParamToggle": true,
+            "allowFullScreen": false,
+            "sizeOptions": {
+              "Small": { "width": 600, "height": 500 },
+              "Medium": { "width": 800, "height": 600},
+              "Large": { "width": 1000, "height": 800},
+              "Custom": {"width": 0, "height": 0}
+            },
+            "selectedOption": "Small"
+          }
+        }
+      },
+        {
+          "name": "DashboardEditor",
+          "cfg": {
+            "selectedService": "localgs",
+            "services": {
+              "localgs": {
+                "url": "/geoserver/wfs",
+                "type": "wfs",
+                "title": "le geoserver local",
+                "autoload": true
+              }
+            },
+            "containerPosition": "columns"
+          }
+        }, {
+          "name": "QueryPanel",
+          "cfg": {
+            "toolsOptions": {
+              "hideCrossLayer": true,
+              "hideSpatialFilter": true
+            },
+            "containerPosition": "columns"
+          }
+        }, "BurgerMenu", "Dashboard", "Notifications", {
+          "name": "Tutorial",
+          "cfg": {
+            "allowClicksThruHole": false,
+            "containerPosition": "header",
+            "preset": "dashboard_tutorial"
+          }
+        },
+        {
+          "name": "FeedbackMask",
+          "cfg": {
+            "containerPosition": "header"
+          }
+        }],
+      "dashboard-embedded": [
+        {
+          "name": "Dashboard",
+          "cfg": {
+            "minLayoutWidth": 768
+          }
+        },
+        { "name": "FeedbackMask" }
+      ],
+      "geostory": [
+        {
+          "name": "OmniBar",
+          "cfg": {
+            "containerPosition": "header",
+            "className": "navbar shadow navbar-home"
+          }
+        },
+        {
+          "name": "Tutorial",
+          "cfg": {
+            "allowClicksThruHole": false,
+            "containerPosition": "header",
+            "preset": "geostory_view_tutorial"
+          }
+        },
+        "Login",
+        "BurgerMenu",
+        "Language",
+        "NavMenu",
+        "Attribution",
+        "Home",
+        {
+          "name": "GeoStory"
+        },
+        "GeoStorySave",
+        "GeoStorySaveAs",
+        "MapEditor",
+        "MediaEditor",
+        {
+          "name": "GeoStoryEditor",
+          "cfg": {
+            "disablePluginIf": "{!!(state('browser') && state('browser').mobile)}",
+            "containerPosition": "columns"
+          }
+        },
+        {
+          "name": "GeoStoryNavigation",
+          "cfg": {
+            "containerPosition": "header"
+          }
+        },
+        "Notifications",
+        {
+          "name": "FeedbackMask",
+          "cfg": {
+            "containerPosition": "header"
+          }
+        },
+        {
+          "name": "Share",
+          "cfg": {
+            "embedPanel": true,
+            "showAPI": false,
+            "embedOptions": {
+              "showTOCToggle": false,
+              "allowFullScreen":false
+            },
+            "shareUrlRegex": "(h[^#]*)#\\/geostory\\/([^\\/]*)\\/([A-Za-z0-9]*)",
+            "shareUrlReplaceString": "$1geostory-embedded.html#/$3",
+            "advancedSettings": {
+              "hideInTab": "embed",
+              "homeButton": true,
+              "sectionId": true
             }
-          }, {
+          }
+        }
+      ],
+      "geostory-embedded": [
+        "GeoStory",
+        {
+          "name": "GeoStoryNavigation",
+          "cfg": {
+            "containerPosition": "header"
+          }
+        },
+        {
+          "name": "FeedbackMask",
+          "cfg": {
+            "containerPosition": "header"
+          }
+        }
+      ],
+      "admin": [{
+        "name": "Header",
           "cfg": {
             "page": "msadmin"
           }
         }, {
+        "name": "OmniBar",
+        "cfg": {
+          "className": "navbar shadow navbar-home"
+        }
+      }, "Login", "ContextManager"],
+      "notallowed": [{
+          "name": "Header",
+          "cfg": {
+            "page": "msadmin"
+          }
+        },
+        {
           "name": "OmniBar",
           "cfg": {
             "className": "navbar shadow navbar-home"
           }
-        }, "Login", "ContextManager"],
-        "notallowed": [{
-            "name": "Header",
-            "cfg": {
-              "page": "msadmin"
-            }
-          },
-          {
-            "name": "OmniBar",
-            "cfg": {
-              "className": "navbar shadow navbar-home"
-            }
-          },
-          "Login",
-          "NotAllowed"
-        ],
-        "context-creator": [
+        },
+        "Login",
+        "NotAllowed"
+      ],
+      "context-creator": [
           {
             "name": "Header",
             "cfg": {
@@ -839,8 +1031,10 @@
             }
           },
           "Login",
+          "Language",
+          "NavMenu",
+          "Attribution",
           "Tutorial",
-
           {
             "name": "ContextCreator",
             "cfg": {


### PR DESCRIPTION
merges https://github.com/georchestra/mapstore2-georchestra/commit/7279757e2f8272a26e0914a7f52cfbb7fb07e4a0#diff-ce67019ec67a33a6f40d0cdc3c72861c85f2a7701ac0d61080d8ff7e80ee9db7
and https://github.com/georchestra/mapstore2-georchestra/commit/b6dcdf46dff586dc9e831e6a68aedb0834085f40#diff-ce67019ec67a33a6f40d0cdc3c72861c85f2a7701ac0d61080d8ff7e80ee9db7

while retaining 2414fe65 (georchestra/mapstore2-georchestra#410 is still pending)

the only customization is pointing at `localgs` for `selectedService` in `DashboardEditor` .. and im not sure keeping the `Home` and `Language` plugins makes sense but thats my POV.

cf georchestra/mapstore2-georchestra#437 & georchestra/mapstore2-georchestra#438