### PR TITLE
make resourceType dynamic

### DIFF
--- a/datafeeder/datafeeder.properties
+++ b/datafeeder/datafeeder.properties
@@ -70,6 +70,11 @@ datafeeder.publishing.geonetwork.auth.headers.[Cookie]=XSRF-TOKEN=c9f33266-e242-
 #datafeeder.publishing.geonetwork.template-record-id:
 datafeeder.publishing.geonetwork.template-record: file:${georchestra.datadir}/datafeeder/metadata_template.xml
 datafeeder.publishing.geonetwork.template-transform: file:${georchestra.datadir}/datafeeder/metadata_transform.xsl
+# you can override the resource type used in the metadata by uncommenting this line:
+# possible values are here:
+# https://github.com/geonetwork/core-geonetwork/blob/main/schemas/iso19139/src/main/plugin/iso19139/schema/resources/Codelist/gmxCodelists.xml#L1538-L1646
+# defaults to series
+#datafeeder.publishing.geonetwork.defaultResourceType=dataset
 
 
 # GeoTools DataStore connection params used inside datafeeder when importing

--- a/datafeeder/metadata_transform.xsl
+++ b/datafeeder/metadata_transform.xsl
@@ -220,9 +220,10 @@ Default template to apply MetadataRecordProperties.java properties to a record t
     </gco:CharacterString>
   </xsl:template>
 
-  <xsl:template match="//gmd:hierarchyLevel/gmd:MD_ScopeCode">
-    <gmd:MD_ScopeCode
-      codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ScopeCode" codeListValue="series" />
+  <xsl:template match="gmd:hierarchyLevel/gmd:MD_ScopeCode/@codeListValue">
+    <xsl:attribute name="codeListValue">
+      <xsl:value-of select="$props//resourceType" />
+    </xsl:attribute>
   </xsl:template>
 
   <xsl:template


### PR DESCRIPTION
fix georchestra/georchestra#3627

The resourceType was not taken from the template, but rather hardcoded to `series`.

( I did some test in my local fork of georchestra/georchestra 
https://github.com/jmbourdaret/georchestra/blob/727bdda7d26e9990613cbd0a4240165a85eb3bca/datafeeder/src/test/java/org/georchestra/datafeeder/service/publish/impl/GeorchestraTemplateMapperTest.java#L136
But as it does not involves any new code, and more importantly is based on copy of templates which are not synchronized with the ones used in the datadir; It is not relevant to push this test to geor/geor. )
