### PR TITLE
Several fixes to the default docker config

### DIFF
--- a/cas/config/cas.properties
+++ b/cas/config/cas.properties
@@ -9,6 +9,8 @@ cas.theme.default-theme-name=georchestra
 cas.service-registry.initFromJson=false
 cas.service-registry.json.location=file:/etc/georchestra/cas/services
 
+cas.authn.accept.enabled=false
+
 cas.authn.ldap[0].ldap-url=ldap://ldap:389/
 cas.authn.ldap[0].bind-dn=
 cas.authn.ldap[0].bind-credential=

--- a/cas/config/log4j2.xml
+++ b/cas/config/log4j2.xml
@@ -2,7 +2,6 @@
 <!-- Specify the refresh internal in seconds. -->
 <Configuration monitorInterval="5" packages="org.apereo.cas.logging">
     <Properties>
-        <Property name="baseDir">/var/log</Property>
         <Property name="cas.log.level">info</Property>
         <Property name="spring.webflow.log.level">warn</Property>
         <Property name="spring.security.log.level">info</Property>
@@ -19,31 +18,6 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout pattern="%highlight{%d %p [%c] - &lt;%m&gt;}%n"/>
         </Console>
-        <RollingFile name="file" fileName="${baseDir}/cas.log" append="true"
-                     filePattern="${baseDir}/cas-%d{yyyy-MM-dd-HH}-%i.log">
-            <PatternLayout pattern="%d %p [%c] - &lt;%m&gt;%n"/>
-            <Policies>
-                <OnStartupTriggeringPolicy />
-                <SizeBasedTriggeringPolicy size="10 MB"/>
-                <TimeBasedTriggeringPolicy />
-            </Policies>
-        </RollingFile>
-        <RollingFile name="auditlogfile" fileName="${baseDir}/cas_audit.log" append="true"
-                     filePattern="${baseDir}/cas_audit-%d{yyyy-MM-dd-HH}-%i.log">
-            <PatternLayout pattern="%d %p [%c] - %m%n"/>
-            <Policies>
-                <OnStartupTriggeringPolicy />
-                <SizeBasedTriggeringPolicy size="10 MB"/>
-                <TimeBasedTriggeringPolicy />
-            </Policies>
-        </RollingFile>
-
-        <CasAppender name="casAudit">
-            <AppenderRef ref="auditlogfile" />
-        </CasAppender>
-        <CasAppender name="casFile">
-            <AppenderRef ref="file" />
-        </CasAppender>
         <CasAppender name="casConsole">
             <AppenderRef ref="console" />
         </CasAppender>
@@ -100,18 +74,7 @@
         <AsyncLogger name="org.ldaptive" level="${sys:ldap.log.level}" includeLocation="true"/>
         <AsyncLogger name="com.hazelcast" level="${sys:hazelcast.log.level}" includeLocation="true"/>
 
-        <!-- Log audit to all root appenders, and also to audit log (additivity is not false) -->
-        <AsyncLogger name="org.apereo.inspektr.audit.support" level="info" includeLocation="true" >
-            <AppenderRef ref="casAudit"/>
-        </AsyncLogger>
-
-        <!-- All Loggers inherit appenders specified here, unless additivity="false" on the Logger -->
         <AsyncRoot level="warn">
-            <AppenderRef ref="casFile"/>
-            <!--
-                 For deployment to an application server running as service,
-                 delete the casConsole appender below
-            -->
             <AppenderRef ref="casConsole"/>
         </AsyncRoot>
     </Loggers>

--- a/datafeeder/datafeeder.properties
+++ b/datafeeder/datafeeder.properties
@@ -20,7 +20,7 @@
 #  Datafeeder specific properties  #
 ####################################
 
-publicUrl=${scheme}://${domainName}
+publicUrl=${scheme:https}://${domainName}
 
 # pgsqlSchema=datafeeder
 
@@ -38,7 +38,7 @@ file-upload.persistent-location=${java.io.tmpdir}/datafeeder/uploads
 front-end.config.uri=file:${georchestra.datadir}/datafeeder/frontend-config.json
 
 datafeeder.publishing.geoserver.api-url=http://geoserver:8080/geoserver/rest
-datafeeder.publishing.geoserver.public-url=${scheme}://${domainName}/geoserver
+datafeeder.publishing.geoserver.public-url=${scheme:https}://${domainName}/geoserver
 # Use this for HTTP basic authentication to geoserver api url:
 #datafeeder.publishing.geoserver.auth.type=basic
 #datafeeder.publishing.geoserver.auth.basic.username=geoserver_privileged_user
@@ -51,7 +51,7 @@ datafeeder.publishing.geoserver.auth.headers.[sec-roles]=ROLE_ADMINISTRATOR
 
 
 datafeeder.publishing.geonetwork.api-url=http://geonetwork:8080/geonetwork
-datafeeder.publishing.geonetwork.public-url=${scheme}://${domainName}/geonetwork
+datafeeder.publishing.geonetwork.public-url=${scheme:https}://${domainName}/geonetwork
 # Use this for HTTP basic authentication to Geonetwork's api url:
 #datafeeder.publishing.geonetwork.auth.type=basic
 #datafeeder.publishing.geonetwork.auth.basic.username=

--- a/datafeeder/templates/analysis-started-email-template.txt
+++ b/datafeeder/templates/analysis-started-email-template.txt
@@ -9,7 +9,7 @@ body:
 Dear ${user.name}, 
 
 Your ${dataset.name} dataset was received correctly and is currently being analyzed.
-Here's a link to the job page: ${scheme}://${domainName}/import/${job.id}
+Here's a link to the job page: ${scheme:https}://${domainName}/import/${job.id}
 
 ---
 Sent by ${instanceName}


### PR DESCRIPTION
# df - using https by default
    
the DF expected the $scheme property to be defined, which isn't since https://github.com/georchestra/datadir/pull/234

# cas - fixing default configuration

* disable default cas fixed credential list (casuser/Mellon). This is not so critical, as even if the authentication will succeed, then the authorization onto the SP (looking up the user from the LDAP to get the roles / orgs ...) won't work, and a 401 will be returned
* removing unused appenders from the log4j2 configuration
