### PR TITLE
Mapstore: Add more plugins to mobile mode

### DIFF
--- a/mapstore/configs/localConfig.json
+++ b/mapstore/configs/localConfig.json
@@ -386,7 +386,20 @@
                 "declineUrl": "https://www.georchestra.org/"
               }
             },
-            "FeedbackMask"
+            "FeedbackMask",
+            {
+              "name": "Share",
+              "cfg": {
+                "showAPI": false,
+                "advancedSettings": {
+                  "bbox": true
+                }
+              }
+            },
+            "MetadataExplorer",
+            "MapImport", 
+            "MapExport",
+            "GlobeViewSwitcher"
         ],
         "desktop": [
           "Header",


### PR DESCRIPTION
The PR adds the following plugins to the "burger" menu:
- "Share"
- "MetadataExplorer" => allows adding layers in mobile mode (which surprisingly does not seem possible for now)
- ~~"Measure" => the angle measuring seems to have a bug on mobile, we should perhaps not add it for now~~
- "MapImport"
- "MapExport"

and button at the bottom right:
- "GlobeViewSwitcher" => allows switching to 3D

Only tested in devtools so far, not on real phone.