### PR TITLE
security-proxy: require logged-in user for /console/account/areaofcompetence

### DIFF
--- a/security-proxy/security-mappings.xml
+++ b/security-proxy/security-mappings.xml
@@ -16,6 +16,7 @@
   <intercept-url pattern="/console/account/new" access="IS_AUTHENTICATED_ANONYMOUSLY" />
   <intercept-url pattern="/console/account/newPassword.*" access="IS_AUTHENTICATED_ANONYMOUSLY" />
   <intercept-url pattern="/console/account/passwordRecovery" access="IS_AUTHENTICATED_ANONYMOUSLY" />
+  <intercept-url pattern="/console/account/areaofcompetence" access="IS_AUTHENTICATED_ANONYMOUSLY" />
   <intercept-url pattern="/console/account/js/.*" access="IS_AUTHENTICATED_ANONYMOUSLY" />
   <intercept-url pattern="/console/account/css/.*" access="IS_AUTHENTICATED_ANONYMOUSLY" />
   <intercept-url pattern="/console/account/fonts/.*" access="IS_AUTHENTICATED_ANONYMOUSLY" />


### PR DESCRIPTION
Makes an unauthenticated call to `/console/account/areaofcompetence` return a 404 instead of redirecting to the login page.

Complements https://github.com/georchestra/georchestra/pull/3869