### PR TITLE
Store GeoNetwork index config embedded inside the webapp

### DIFF
--- a/geonetwork/geonetwork.properties
+++ b/geonetwork/geonetwork.properties
@@ -16,6 +16,7 @@ geonetwork.resources.dir=${geonetwork.dir}/data/resources/
 geonetwork.upload.dir=${geonetwork.dir}/data/upload/
 geonetwork.formatter.dir=${geonetwork.dir}/data/formatter/
 geonetwork.htmlcache.dir=${geonetwork.resources.dir}/htmlcache/
+geonetwork.indexConfig.dir=/var/lib/jetty/webapps/geonetwork/WEB-INF/data/config/index
 
 # AuthNZ integration uses console's REST API to fetch the canonical
 # users and groups, regardless of where geOrchestra gets them from (LDAP or otherwise)


### PR DESCRIPTION
Otherwise the index config will be persisted in an external datadir and won't be updated automatically when upgrading GeoNetwork.