### PR TITLE
Add a setting for the GeoNetwork index config path

### DIFF
--- a/geonetwork/geonetwork.properties
+++ b/geonetwork/geonetwork.properties
@@ -16,6 +16,7 @@ geonetwork.resources.dir=${geonetwork.dir}/data/resources/
 geonetwork.upload.dir=${geonetwork.dir}/data/upload/
 geonetwork.formatter.dir=${geonetwork.dir}/data/formatter/
 geonetwork.htmlcache.dir=${geonetwork.resources.dir}/htmlcache/
+geonetwork.indexConfig.dir=${geonetwork.config.dir}/index/
 
 # AuthNZ integration uses console's REST API to fetch the canonical
 # users and groups, regardless of where geOrchestra gets them from (LDAP or otherwise)


### PR DESCRIPTION
This setting uses the `geonetwork.config.dir` variable, so that if someone makes this variable point to the embedded files in the webapp, this will also work for the index config.

Followup of https://github.com/georchestra/datadir/pull/259