### PR TITLE
proxy - add mapping for datahub

### DIFF
--- a/security-proxy/targets-mapping.properties
+++ b/security-proxy/targets-mapping.properties
@@ -10,3 +10,4 @@ geowebcache=http://geowebcache:8080/geowebcache/
 mapstore=http://mapstore:8080/mapstore/
 datafeeder=http://datafeeder:8080/datafeeder
 import=http://import:80/
+datahub=http://datahub:80/datahub/


### PR DESCRIPTION
Targeting only `docker-master` because datahub is integrated in the docker composition only