### PR TITLE
[sec-proxy] add missing cookie-mappings.json file

### DIFF
--- a/security-proxy/cookie-mappings.json
+++ b/security-proxy/cookie-mappings.json
@@ -1,0 +1,7 @@
+[
+	{
+		"name": "XSRF-TOKEN",
+		"from": "/geonetwork",
+		"to": "/datahub"
+	}
+]


### PR DESCRIPTION
required for favourite metadata feature to work in datahub

cf georchestra/georchestra#3851