### PR TITLE
add beta urls for geoplateforme ogc sources (#307)

### DIFF
--- a/mapstore/configs/localConfig.json
+++ b/mapstore/configs/localConfig.json
@@ -142,16 +142,47 @@
                 "title": "IGN essentiels RASTER",
                 "autoload": true
               },
+              "gpfbetarasterwms": {
+                "url": "https://wms-r.geopf.fr/rok4/wms",
+                "type": "wms",
+                "title": "Géoplateforme (béta) RASTER",
+                "autoload": true
+              },
               "ignvectorwms": {
                 "url": "https://wxs.ign.fr/essentiels/geoportail/v/wms",
                 "type": "wms",
                 "title": "IGN essentiels VECTOR",
                 "autoload": true
               },
+              "gpfbetavectorwms": {
+                "url": "https://wms-v.geopf.fr/geoserver/ows",
+                "type": "wms",
+                "title": "Géoplateforme (béta) VECTOR",
+                "autoload": true
+              },
+              "gpfbetawfs": {
+                "url": "https://wfs.geopf.fr/geoserver/ows",
+                "type": "wfs",
+                "title": "Géoplateforme (béta) WFS",
+                "autoload": true
+              },
               "ignwmts": {
                 "url": "https://wxs.ign.fr/essentiels/geoportail/wmts",
                 "type": "wmts",
                 "title": "IGN essentiels WMTS",
+                "autoload": true
+              },
+              "gpfbetawmts": {
+                "url": "https://wmts.geopf.fr/rok4/wmts",
+                "type": "wmts",
+                "title": "Géoplateforme (béta) WMTS",
+                "autoload": true
+              },
+              "gpfbetatms": {
+                "url": "https://wmts.geopf.fr/rok4/tms/1.0.0/",
+                "type": "tms",
+                "provider":"tms",
+                "title": "Géoplateforme (béta) TMS",
                 "autoload": true
               },
               "igndecouvertewmts": {


### PR DESCRIPTION
lightly tested, `/mapstore/proxy` looks slightly broken (cf https://demo.georchestra.org/mapstore/proxy/?url=https%3A%2F%2Fwms-v.geopf.fr%2Fgeoserver%2Fows%3Fservice%3DWMS%26version%3D1.3.0%26request%3DGetCapabilities  but thats unrelated to this change)

https://wms-v.geopf.fr & https://wfs.geopf.fr use geoserver, thus refuse to work if added to `useCors` array `(Reason: CORS Missing Allow Origin)`. using the mapstore proxy seems mandatory for those.

raster, tms & wmts seems to work.

will push to https://github.com/georchestra/mapstore2-georchestra/blob/master/configs/localConfig.json too

closes #307