### PR TITLE
Pre-expose parameters for hikari pooling

### DIFF
--- a/geonetwork/microservices/ogc-api-records/config.yml
+++ b/geonetwork/microservices/ogc-api-records/config.yml
@@ -22,6 +22,10 @@ spring:
     url: jdbc:postgresql://localhost:5432/georchestra?currentSchema=geonetwork
     username: georchestra
     password: georchestra
+    hikari:
+      pool-name: ogc-api-records
+      minimum-idle: 1
+      maximum-pool-size: 10
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     jpa.generate-ddl: false


### PR DESCRIPTION
on ogc-api-records

Also force by default a maximum amount of connections in ogc-api-records