### PR TITLE
Added LDAP admin credentials for OAuth2 account creation

### DIFF
--- a/gateway/security.yaml
+++ b/gateway/security.yaml
@@ -9,6 +9,8 @@ georchestra:
           extended: true
           url: ldap://ldap:389/
           baseDn: ${ldapBaseDn:dc=georchestra,dc=org}
+          adminDn: ${ldapAdminDn:cn=admin,dc=georchestra,dc=org"}
+          adminPassword: ${ldapAdminPassword:secret}
           users:
             rdn: ${ldapUsersRdn:ou=users}
             searchFilter: ${ldapUserSearchFilter:(uid={0})}


### PR DESCRIPTION
When authenticating from OAuth2 using the gateway, we need to create a local account if there is none. So we need admin credentials to LDAP.