### PR TITLE
Fix default header url in the datahub add-header script

### DIFF
--- a/datahub/scripts/add-header.sh
+++ b/datahub/scripts/add-header.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 DATAHUB_DIR=${1:-/usr/share/nginx/html/datahub}
-SNIPPET="<iframe src='/portail/banner?active=datahub' style='height:90px; width: 100%; border: 0; overflow: hidden'></iframe>"
+SNIPPET="<iframe src='/header/?active=datahub' style='height:90px; width: 100%; border: 0; overflow: hidden'></iframe>"
 
 if grep -q "${SNIPPET}" "${DATAHUB_DIR}/index.html"; then
   echo "[INFO] geOrchestra: header already present."


### PR DESCRIPTION
@jeanmi151 That should work better for a vanilla geOrchestra installation!