### PR TITLE
adding cookie affinity in gateway config for geonetowrk/datahub

### DIFF
--- a/gateway/routes.yaml
+++ b/gateway/routes.yaml
@@ -27,6 +27,12 @@ spring:
         uri: ${georchestra.gateway.services.geonetwork.target}
         predicates:
         - Path=/geonetwork/**
+        filters:
+        - name: CookieAffinity
+          args:
+            name: XSRF-TOKEN
+            from: /geonetwork
+            to: /datahub
       - id: geoserver
         uri: ${georchestra.gateway.services.geoserver.target}
         predicates:


### PR DESCRIPTION
after merging need to be ported to docker-master