### PR TITLE
datafeeder - variabilize fqdn

### DIFF
--- a/datafeeder/frontend-config.json
+++ b/datafeeder/frontend-config.json
@@ -23,5 +23,5 @@
       "value": "EPSG:3857"
     }
   ],
-  "thesaurusUrl": "https://georchestra-127-0-1-1.traefik.me/geonetwork/srv/api/registries/vocabularies/search?type=CONTAINS&thesaurus=external.theme.httpinspireeceuropaeutheme-theme&rows=200&q=${q}&uri=**&lang=${lang}"
+  "thesaurusUrl": "https://${FQDN}/geonetwork/srv/api/registries/vocabularies/search?type=CONTAINS&thesaurus=external.theme.httpinspireeceuropaeutheme-theme&rows=200&q=${q}&uri=**&lang=${lang}"
 }

--- a/datafeeder/metadata_template.xml
+++ b/datafeeder/metadata_template.xml
@@ -135,7 +135,7 @@
               <gmd:identifier>
                 <gmd:MD_Identifier>
                   <gmd:code>
-                    <gmx:Anchor xlink:href="https://georchestra-127-0-1-1.traefik.me/geonetwork/srv/api/registries/vocabularies/external.theme.httpinspireeceuropaeutheme-theme">geonetwork.thesaurus.external.theme.httpinspireeceuropaeutheme-theme</gmx:Anchor>
+                    <gmx:Anchor xlink:href="https://${FQDN}/geonetwork/srv/api/registries/vocabularies/external.theme.httpinspireeceuropaeutheme-theme">geonetwork.thesaurus.external.theme.httpinspireeceuropaeutheme-theme</gmx:Anchor>
                   </gmd:code>
                 </gmd:MD_Identifier>
               </gmd:identifier>

--- a/datafeeder/metadata_transform.xsl
+++ b/datafeeder/metadata_transform.xsl
@@ -91,7 +91,7 @@ Default template to apply MetadataRecordProperties.java properties to a record t
           <gmd:identifier>
             <gmd:MD_Identifier>
               <gmd:code>
-                <gmx:Anchor xlink:href="https://georchestra-127-0-1-1.traefik.me/geonetwork/srv/api/registries/vocabularies/external.theme.httpinspireeceuropaeutheme-theme">geonetwork.thesaurus.external.theme.httpinspireeceuropaeutheme-theme</gmx:Anchor>
+                <gmx:Anchor xlink:href="https://${FQDN}/geonetwork/srv/api/registries/vocabularies/external.theme.httpinspireeceuropaeutheme-theme">geonetwork.thesaurus.external.theme.httpinspireeceuropaeutheme-theme</gmx:Anchor>
               </gmd:code>
             </gmd:MD_Identifier>
           </gmd:identifier>


### PR DESCRIPTION
We should use the `envsubst` service (https://github.com/georchestra/docker/blob/fe09e0aa2afd0259627c74f75a7bb356050cd335/docker-compose.yml#L33C3-L44) to have template URLs pointing at the instance fqdn by default.