### PR TITLE
gateway - DataFeeder expects the JSON versions of the http headers

### DIFF
--- a/gateway/gateway.yaml
+++ b/gateway/gateway.yaml
@@ -34,6 +34,9 @@ georchestra:
           allowed-roles: SUPERUSER,ORGADMIN
       datafeeder:
         target: ${georchestra.gateway.services.datafeeder.target}
+        headers:
+          json-user: true
+          json-organization: true
         access-rules:
         - intercept-url: /datafeeder/**
           anonymous: false


### PR DESCRIPTION
Runtime tested on the MEL platform, been able to load a dataset using the DF afterwards.