### PR TITLE
correcting key value in datafeeder configuration

### DIFF
--- a/datafeeder/datafeeder.properties
+++ b/datafeeder/datafeeder.properties
@@ -85,7 +85,7 @@ datafeeder.publishing.backend.local.host=${pgsqlHost}
 datafeeder.publishing.backend.local.port=${pgsqlPort}
 datafeeder.publishing.backend.local.database=${pgsqlDatabase}
 #<schema> is a placeholder to be replaced by the actual schema computed from the "sec-org" request header
-datafeeder.publishing.backend.geoserver.schema=<schema>
+datafeeder.publishing.backend.local.schema=<schema>
 datafeeder.publishing.backend.local.user=${pgsqlUser}
 datafeeder.publishing.backend.local.passwd=${pgsqlPassword}
 datafeeder.publishing.backend.local.preparedStatements=true


### PR DESCRIPTION
the key of the modified line was wrong if we follow the config schema from here : https://github.com/georchestra/georchestra/blob/master/datafeeder/src/main/resources/application.yml#L152

and here: https://github.com/georchestra/georchestra/blob/master/datafeeder/src/test/resources/datadir/datafeeder/datafeeder.properties#L87C1-L87C43

maybe the value should also be modified if we want to be aligned with previous links
