### PR TITLE
drop soon-to-be deprecated wxs.ign.fr and update default map

### DIFF
--- a/mapstore/configs/config.json
+++ b/mapstore/configs/config.json
@@ -26,7 +26,7 @@
         "type": "wmts",
         "group": "background",
         "thumbURL": "/mapstore/dist/MapStore2/web/client/plugins/background/assets/img/Aerial.jpg",
-        "url": "https://wxs.ign.fr/decouverte/geoportail/wmts",
+        "url" : "https://data.geopf.fr/wmts",
         "name": "ORTHOIMAGERY.ORTHOPHOTOS",
         "format": "image/jpeg",
         "style": "normal",
@@ -57,7 +57,7 @@
       }
     ],
     "sources": {
-      "https://wxs.ign.fr/decouverte/geoportail/wmts": {
+      "https://data.geopf.fr/wmts" : {
         "tileMatrixSet": {
           "PM": {
             "ows:Identifier": "PM",

--- a/mapstore/configs/localConfig.json
+++ b/mapstore/configs/localConfig.json
@@ -134,22 +134,10 @@
                 "title": "Service de données de la plateforme",
                 "autoload": true
               },
-              "ignrasterwms": {
-                "url": "https://wxs.ign.fr/essentiels/geoportail/r/wms",
-                "type": "wms",
-                "title": "IGN essentiels RASTER",
-                "autoload": true
-              },
               "gpfrasterwms": {
                 "url": "https://data.geopf.fr/wms-r/wms",
                 "type": "wms",
                 "title": "Géoplateforme RASTER",
-                "autoload": true
-              },
-              "ignvectorwms": {
-                "url": "https://wxs.ign.fr/essentiels/geoportail/v/wms",
-                "type": "wms",
-                "title": "IGN essentiels VECTOR",
                 "autoload": true
               },
               "gpfvectorwms": {
@@ -162,12 +150,6 @@
                 "url": "https://data.geopf.fr/wfs/ows",
                 "type": "wfs",
                 "title": "Géoplateforme WFS",
-                "autoload": true
-              },
-              "ignwmts": {
-                "url": "https://wxs.ign.fr/essentiels/geoportail/wmts",
-                "type": "wmts",
-                "title": "IGN essentiels WMTS",
                 "autoload": true
               },
               "gpfwmts": {
@@ -187,42 +169,6 @@
                 "url": "https://data.geopf.fr/csw",
                 "type": "csw",
                 "title": "Géoplateforme CSW",
-                "autoload": true
-              },
-              "igndecouvertewmts": {
-                "url": "https://wxs.ign.fr/decouverte/geoportail/wmts",
-                "type": "wmts",
-                "title": "IGN decouverte WMTS",
-                "autoload": true
-              },
-              "igncartovectowms": {
-                "url": "https://wxs.ign.fr/cartovecto/geoportail/v/wms",
-                "type": "wms",
-                "title": "IGN carto vectorielle",
-                "autoload": true
-              },
-              "ignadministratifwms": {
-                "url": "https://wxs.ign.fr/administratif/geoportail/r/wms",
-                "type": "wms",
-                "title": "IGN administratif",
-                "autoload": true
-              },
-              "ignadressewms": {
-                "url": "https://wxs.ign.fr/adresse/geoportail/v/wms",
-                "type": "wms",
-                "title": "IGN adresse",
-                "autoload": true
-              },
-              "ignagriculturewms": {
-                "url": "https://wxs.ign.fr/agriculture/geoportail/r/wms",
-                "type": "wms",
-                "title": "IGN agriculture",
-                "autoload": true
-              },
-              "ignaltimetriewmts": {
-                "url": "https://wxs.ign.fr/altimetrie/geoportail/wmts",
-                "type": "wmts",
-                "title": "IGN altimetrie WMTS",
                 "autoload": true
               },
               "sandre": {


### PR DESCRIPTION
fixes #346 and removes the services that will disappear in a month, cf https://geoservices.ign.fr/bascule-vers-la-geoplateforme

probably needs backport to stable branches