### PR TITLE
fix #361: set datahub lang to all

### DIFF
--- a/datahub/conf/default.toml
+++ b/datahub/conf/default.toml
@@ -13,7 +13,7 @@ proxy_path = "/proxy/?url="
 # This optional parameter defines, in which language metadata should be queried in elasticsearch.
 # Use ISO 639-2/B (https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format to indicate the language of the metadata.
 # If not indicated, a wildcard is used and no language preference is applied for the search.
-metadata_language = "fre"
+# metadata_language = "fre"
 # This optional URL should point to the login page that allows authentication to the datahub.
 # If not indicated, the default geonetwork login page is used.
 # The following three placeholders can be part of this URL:


### PR DESCRIPTION
Solves datahub searching only in french. 

Needs to be backported to master.