### PR TITLE
disable rabbitmq by default

### DIFF
--- a/default.properties
+++ b/default.properties
@@ -78,7 +78,7 @@ pgsqlPassword=${PGPASSWORD}
 ### rabbitmq properties
 
 # Activate/deactivate Rabbitmq
-enableRabbitmqEvents=true
+enableRabbitmqEvents=false
 
 # rabbitmq server domain name
 rabbitmqHost=${RABBITMQ_HOST}


### PR DESCRIPTION
by default rabbitmq should not be enable as it is useless (for now) and not supported officially

connected with : https://github.com/georchestra/docker/pull/262 