### PR TITLE
[mapstore] enable PNG and JPG print output formats

### DIFF
--- a/mapstore/configs/localConfig.json
+++ b/mapstore/configs/localConfig.json
@@ -534,6 +534,13 @@
                 "mapPreviewOptions": {
                   "enableScalebox": true
                 },
+                "outputFormatOptions": {
+                  "allowedFormats": [
+                    { "name": "PDF", "value": "pdf" },
+                    { "name": "PNG", "value": "png" },
+                    { "name": "JPG", "value": "jpg" }
+                  ]
+                },
                 "overlayLayersOptions": {
                   "enabled": true
                 }


### PR DESCRIPTION
all formats are already enabled in mapfish-print cf https://github.com/georchestra/datadir/blob/master/mapstore/printing/config.yaml#L31