### PR TITLE
cas - adding default properties for saml provider to work

### DIFF
--- a/cas/config/cas.properties
+++ b/cas/config/cas.properties
@@ -47,4 +47,7 @@ cas.authn.ldap[0].name=
 
 cas.authn.ldap[0].type=DIRECT
 cas.authn.ldap[0].dn-format=uid=%s,ou=users,dc=georchestra,dc=org
-cas.authn.oidc.jwks.jwks-file=file:///tmp/keystore.jwksdown 
+cas.authn.oidc.jwks.jwks-file=file:///tmp/keystore.jwksdown
+
+cas.authn.saml-idp.core.entity-id=https://${FQDN}/idp
+cas.authn.saml-idp.metadata.location=file:///tmp/


### PR DESCRIPTION
Following https://github.com/georchestra/georchestra-cas-server/pull/25 we now need these to make sure cas is able to run.

Same as #387, but targeting `docker-master`.
