### PR TITLE
add missing service definition/url for gwc

### DIFF
--- a/gateway/routes.yaml
+++ b/gateway/routes.yaml
@@ -71,6 +71,7 @@ georchestra.gateway.services:
   datahub.target: http://localhost:8280/datahub/
   geonetwork.target: http://localhost:8280/geonetwork/
   geoserver.target: http://localhost:8380/geoserver/
+  geowebcache.target: http://localhost:8380/geowebcache/
   header.target: http://localhost:8280/header/
   import.target: http://localhost:8280/import/
   mapstore.target: http://localhost:8280/mapstore/


### PR DESCRIPTION
required to have the gateway start, cf https://github.com/georchestra/ansible/issues/128#issuecomment-2012642332

the entry for gwc was added in b6d3e8b97 but seemed incomplete. It had previously been removed in 40743b38, and isnt present in https://github.com/georchestra/datadir/blob/master/security-proxy/targets-mapping.properties, so at that point i have no idea if it should be here or not. But as it is now the gw doesnt start with a datadir from master branch, cf georchestra/ansible#128.

looking at my PR, if gwc should be enabled, i dunno if it should be deployed in the same tomcat as geoserver. the ansible playbook deploys it in the georchestra tomcat instance, on a different port, but the list of rules should be generated from the playbook config.