### PR TITLE
console - fixed missing email subject on user email changed

### DIFF
--- a/console/console.properties
+++ b/console/console.properties
@@ -255,6 +255,10 @@ AreasGroup=INSEE_DEP
 # default: [${instanceName}] Update your password
 #subject.change.password=[${instanceName}] Update your password
 
+# Subject of email for email change
+# default: [${instanceName}] Update your email address
+#subject.change.email=[${instanceName}] Update your email address
+
 # Subject of email for login change
 # default: [${instanceName}] New login for your account
 #subject.account.uid.renamed=[${instanceName}] New login for your account


### PR DESCRIPTION
Added parameter for email sent when email address change is requested.
See [console PR#4208](https://github.com/georchestra/georchestra/pull/4208)