### PR TITLE
Redirect to datahub and not header and dont call areaofcompetence

### DIFF
--- a/datahub/conf/default.toml
+++ b/datahub/conf/default.toml
@@ -69,7 +69,7 @@ fonts_stylesheet_url = "https://fonts.googleapis.com/css2?family=Display&family=
 # Optional; specify a GeoJSON object to be used as filter: all records contained inside the geometry will be boosted on top,
 # all records which do not intersect with the geometry will be shown with lower priority; can be specified as URL or inline
 # Note: if the GeoJSON object contains multiple features, only the geometry of the first one will be kept!
-filter_geometry_url = "/console/account/areaofcompetence"
+#filter_geometry_url = "/console/account/areaofcompetence"
 # filter_geometry_data = '{ "coordinates": [...], "type": "Polygon" }'
 
 # The advanced search filters available to the user can be customized with this setting.

--- a/default.properties
+++ b/default.properties
@@ -83,13 +83,13 @@ enableRabbitmqEvents=false
 # rabbitmq server domain name
 rabbitmqHost=localhost
 
-# rabbitmq user 
+# rabbitmq user
 rabbitmqUser=georchestra
 
-# rabbitmq password 
+# rabbitmq password
 rabbitmqPassword=georchestra
 
-# rabbitmq port 
+# rabbitmq port
 rabbitmqPort=5672
 
 ### LDAP properties
@@ -144,10 +144,10 @@ smtpHost=localhost
 # Listening port of the SMTP server
 smtpPort=25
 
-# Activates analytics 
+# Activates analytics
 # WARNING : When using the geOrchestra gateway, analytics should be disabled
-# if set to true, the analytics app will be enabled (https://github.com/georchestra/georchestra/tree/master/analytics) 
+# if set to true, the analytics app will be enabled (https://github.com/georchestra/georchestra/tree/master/analytics)
 # console will add all links to analytics and also execute XHR requests
 # header will diplay analytics app
 # default: true
-# analyticsEnabled=true
+analyticsEnabled=false

--- a/gateway/routes.yaml
+++ b/gateway/routes.yaml
@@ -6,11 +6,11 @@ spring:
     gateway:
       routes:
       - id: root
-        uri: ${georchestra.gateway.services.header.target}
+        uri: ${georchestra.gateway.services.datahub.target}
         predicates:
         - Path=/
         filters:
-        - RedirectTo=308, /header
+        - RedirectTo=308, /datahub/
       - id: header
         uri: ${georchestra.gateway.services.header.target}
         predicates:


### PR DESCRIPTION
For gateway and 24, redirect to datahub and not legacy header and don't execute call to areaofcompetence 

Also disable analytics