### PR TITLE
[console] add commented out parameters for georchestra/georchestra#4189

### DIFF
--- a/console/console.properties
+++ b/console/console.properties
@@ -327,6 +327,15 @@ AreasGroup=INSEE_DEP
 # default: true
 #gdpr.allowAccountDeletion=true
 
+# PostGreSQL database connection parameters to geonetwork for GDPR 'export my data'
+# should match jdbc.* entries in geonetwork.properties
+# uncomment to override
+#pgsqlGNHost=localhost
+#pgsqlGNPort=${psql.port}
+#pgsqlGNDatabase=georchestra
+#pgsqlGNUser=georchestra
+#pgsqlGNPassword=georchestra
+
 # Activates area of competence
 # if set to true, enable competence area in the account form and in organization page
 # default: false


### PR DESCRIPTION
cf  georchestra/georchestra#4189 & georchestra/georchestra#4168 .. and thinking about it i wonder if it'd be better to move those to `default.properties` but that's more work in the xml config goo for both geonetwork and console.