### PR TITLE
add a logger config for org.geonetwork.security.external.integration

### DIFF
--- a/geonetwork/log4j/log4j2.xml
+++ b/geonetwork/log4j/log4j2.xml
@@ -93,6 +93,9 @@
     <Logger name="org.springframework.security.ldap" level="error"/>
     <Logger name="org.springframework.aop.framework.CglibAopProxy" level="error"/>
 
+    <!-- geOrchestra user/groups/roles synchronization -->
+    <Logger name="org.geonetwork.security.external.integration" level="warn"/>
+
     <Logger name="com.k_int" level="error" additivity="false">
       <AppenderRef ref="Console"/>
       <AppenderRef ref="File"/>


### PR DESCRIPTION
this way we cant see errors and warnings when sync fails... otherwise the errors are just silently dropped.

witnessed on demo.geor where we didnt understand why sync wasnt working, those messages were not logged....
```
2024-06-27T09:15:52,763 WARN  [org.geonetwork.security.external.integration] - Synchronization failed, retrying in 10 SECONDS.
org.springframework.dao.InvalidDataAccessApiUsageException: The given id must not be null!; nested exception is java.lang.IllegalArgumentException: The given id must not be null!
```
needs backport to 24.0 branch