### PR TITLE
[cas] one logfile a day is enough

### DIFF
--- a/cas/config/log4j2.xml
+++ b/cas/config/log4j2.xml
@@ -20,7 +20,7 @@
             <PatternLayout pattern="%highlight{%d %p [%c] - &lt;%m&gt;}%n"/>
         </Console>
         <RollingFile name="file" fileName="${baseDir}/cas.log" append="true"
-                     filePattern="${baseDir}/cas-%d{yyyy-MM-dd-HH}-%i.log">
+                     filePattern="${baseDir}/cas-%d{yyyy-MM-dd}-%i.log">
             <PatternLayout pattern="%d %p [%c] - &lt;%m&gt;%n"/>
             <Policies>
                 <OnStartupTriggeringPolicy />
@@ -29,7 +29,7 @@
             </Policies>
         </RollingFile>
         <RollingFile name="auditlogfile" fileName="${baseDir}/cas_audit.log" append="true"
-                     filePattern="${baseDir}/cas_audit-%d{yyyy-MM-dd-HH}-%i.log">
+                     filePattern="${baseDir}/cas_audit-%d{yyyy-MM-dd}-%i.log">
             <PatternLayout pattern="%d %p [%c] - %m%n"/>
             <Policies>
                 <OnStartupTriggeringPolicy />


### PR DESCRIPTION
because having 24 files a day, filled with garbage every minute:
```
2024-06-27 00:15:07,361 WARN [org.apereo.cas.services.RegexRegisteredService] - <CAS has located a service definition type that is now tagged as [RegexRegisteredService]. This registered service definition type is scheduled for removal and should no longer be used for CAS-enabled applications, and MUST be replaced with [org.apereo.cas.services.CasRegisteredService] instead. We STRONGLY advise that you update your service definitions and make the replacement to facilitate future CAS upgrades.>
2024-06-27 00:16:07,362 WARN [org.apereo.cas.services.RegexRegisteredService] - <CAS has located a service definition type that is now tagged as [RegexRegisteredService]. This registered service definition type is scheduled for removal and should no longer be used for CAS-enabled applications, and MUST be replaced with [org.apereo.cas.services.CasRegisteredService] instead. We STRONGLY advise that you update your service definitions and make the replacement to facilitate future CAS upgrades.>
2024-06-27 00:16:59,336 INFO [org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner] - <[0] expired tickets removed.>
2024-06-27 00:17:07,363 WARN [org.apereo.cas.services.RegexRegisteredService] - <CAS has located a service definition type that is now tagged as [RegexRegisteredService]. This registered service definition type is scheduled for removal and should no longer be used for CAS-enabled applications, and MUST be replaced with [org.apereo.cas.services.CasRegisteredService] instead. We STRONGLY advise that you update your service definitions and make the replacement to facilitate future CAS upgrades.>
2024-06-27 00:18:07,364 WARN [org.apereo.cas.services.RegexRegisteredService] - <CAS has located a service definition type that is now tagged as [RegexRegisteredService]. This registered service definition type is scheduled for removal and should no longer be used for CAS-enabled applications, and MUST be replaced with [org.apereo.cas.services.CasRegisteredService] instead. We STRONGLY advise that you update your service definitions and make the replacement to facilitate future CAS upgrades.>
2024-06-27 00:18:59,336 INFO [org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner] - <[0] expired tickets removed.>

```
is a bit too much. will check in a separate PR the Regex vs Cas thing..