### PR TITLE
[cas] use CasRegisteredService instead of RegexRegisteredService

### DIFF
--- a/cas/services/georchestra-1001.json
+++ b/cas/services/georchestra-1001.json
@@ -1,5 +1,5 @@
 {
-    "@class" : "org.apereo.cas.services.RegexRegisteredService",
+    "@class" : "org.apereo.cas.services.CasRegisteredService",
     "serviceId" : "^https?://.*$",
     "name" : "georchestra",
     "id" : 1001,


### PR DESCRIPTION
strongly advised by upstream since 6.6, cf https://apereo.github.io/cas/6.6.x/release_notes/RC3.html#cas-registered-services

with that, i don't have 
```
2024-06-27 00:17:07,363 WARN [org.apereo.cas.services.RegexRegisteredService] - <CAS has located a service definition type that is now tagged as [RegexRegisteredService]. This registered service definition type is scheduled for removal and should no longer be used for CAS-enabled applications, and MUST be replaced with [org.apereo.cas.services.CasRegisteredService] instead. We STRONGLY advise that you update your service definitions and make the replacement to facilitate future CAS upgrades.>
```

every minute in the logfile (cf #410), and cas login still works.