### PR TITLE
Set mapstore as proxy and update conf

### DIFF
--- a/datahub/conf/default.toml
+++ b/datahub/conf/default.toml
@@ -10,7 +10,7 @@ datahub_url = "/datahub"
 # This should point to a proxy to avoid CORS errors on some requests (data preview, OGC capabilities etc.)
 # The actual URL will be appended after this path, e.g. : https://my.proxy/?url=http%3A%2F%2Fencoded.url%2Fows`
 # This is an optional parameter: leave empty to disable proxy usage
-proxy_path = "/proxy/?url="
+proxy_path = "/mapstore/proxy/?url="
 # This optional parameter defines, in which language metadata should be queried in elasticsearch.
 # Use ISO 639-2/B (https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format to indicate the language of the metadata.
 # Setting to "current" will use the current language of the User Interface.

--- a/mapstore/proxy.properties
+++ b/mapstore/proxy.properties
@@ -35,7 +35,7 @@ methodsWhitelist = GET,POST,PUT
 # only urls matching one of the whitelist will be forwarded
 #reqtypeWhitelist.capabilities = (([&]?([Rr][Ee][Qq][Uu][Ee][Ss][Tt]=[Gg]et[Cc]apabilities))|([&]?(version=1\\.1\\.1)))+
 reqtypeWhitelist.capabilities = .*[Gg]et[Cc]apabilities.*
-reqtypeWhitelist.featureinfo = .*[Gg]et[Ff]eature[Ii]nfo.*
+reqtypeWhitelist.featureinfo = .*[Gg]et[Ff]eature.*
 reqtypeWhitelist.csw = .*csw.*
 reqtypeWhitelist.geostore = .*geostore.*
-reqtypeWhitelist.generic = (.*exist.*)|(.*pdf.*)|(.*map.*)|(.*wms.*)|(.*wmts.*)|(.*wfs.*)|(.*ows.*)
+reqtypeWhitelist.generic = (.*exist.*)|(.*pdf.*)|(.*map.*)|(.*wms.*)|(.*wmts.*)|(.*wfs.*)|(.*ows.*)|(.*geojson.*)|(.*csv.*)|(.*ogcapi.*)


### PR DESCRIPTION
 to allow ogcapi,csv,json and getFeature

This allows datahub to use mapstore proxy and extends default config to read more data