### PR TITLE
Use a GatewayFilter to redirect to the login page when given a login query parameter

### DIFF
--- a/gateway/application.yaml
+++ b/gateway/application.yaml
@@ -22,6 +22,7 @@ spring:
         # AddSecHeaders appends sec-* headers to proxied requests based on the currently authenticated user
         - AddSecHeaders
         - PreserveHostHeader
+        - LoginParamRedirect #redirects all request with a ?login query param to /login
       filter:
         secure-headers:
           referrer-policy: strict-origin

--- a/gateway/security.yaml
+++ b/gateway/security.yaml
@@ -1,6 +1,14 @@
 georchestra:
   gateway:
     security:
+      header-authentication:
+        # If enabled, pre-authentication is enabled and can be performed by passing
+        # true to the sec-georchestra-preauthenticated request header, and user details
+        # through the following request headers: preauth-username, preauth-firstname,
+        # preauth-lastname, preauth-org, preauth-email, preauth-roles.
+        # In such case, it is crucial for the reverse proxy in front of the gateway to
+        # sanitize the mentioned request headers to prevent external impersonation.
+        enabled: false
       createNonExistingUsersInLDAP: true
       enableRabbitmqEvents: true
       oauth2:


### PR DESCRIPTION
Configuration required for this gateway change:
https://github.com/georchestra/georchestra-gateway/pull/133

This patch adds the `LoginParamRedirect` default filter to the gateway.

Note the filter is added by default in the embedded `application.yml`, but since `gateway/application.yaml` is overriding the `spring.cloud.gateway.default-filters` list, it must be added here too.