### PR TITLE
set back to the default default-filters

### DIFF
--- a/gateway/application.yaml
+++ b/gateway/application.yaml
@@ -15,14 +15,6 @@ server:
 spring:
   cloud:
     gateway:
-      default-filters:
-        - SecureHeaders
-        - TokenRelay
-        - RemoveSecurityHeaders
-        # AddSecHeaders appends sec-* headers to proxied requests based on the currently authenticated user
-        - AddSecHeaders
-        - PreserveHostHeader
-        - LoginParamRedirect #redirects all request with a ?login query param to /login
       filter:
         secure-headers:
           referrer-policy: strict-origin


### PR DESCRIPTION
Set back to the default values of default-filters

There is no need to define only some of them, all the default-filters are useful. Some of them are useful because they fix some logic about /?login=, see https://github.com/georchestra/georchestra-gateway/pull/133