### PR TITLE
console - adding gdpr.displayMembersList

### DIFF
--- a/console/console.properties
+++ b/console/console.properties
@@ -341,6 +341,10 @@ AreasGroup=INSEE_DEP
 # default: true
 #gdpr.allowAccountDeletion=true
 
+# Activates organization's member list in user details edition page /console/account/userdetails
+# default: false
+#gdpr.displayMembersList=false
+
 # PostGreSQL database connection parameters to geonetwork for GDPR 'export my data'
 # should match jdbc.* entries in geonetwork.properties
 # uncomment to override


### PR DESCRIPTION
Allows to display organization's members list in `/console/account/userdetails`
![image](https://github.com/user-attachments/assets/e61b7299-6937-44db-b31d-42a0ded2a572)
