### PR TITLE
Move away from traefik.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Note that if you are developing, and running the servlet container with the Mave
 
 ## 3-steps editing
 
-Before using this datadir, you should at least change the default FQDN (`georchestra-127-0-1-1.traefik.me`) for yours.
+Before using this datadir, you should at least change the default FQDN (`georchestra-127-0-0-1.nip.io`) for yours.
 This can be done very easily with eg:
 ```
 cd /etc/georchestra
-find ./ -type f -exec sed -i 's/georchestra-127-0-1-1.traefik.me/my.fqdn/' {} \;
+find ./ -type f -exec sed -i 's/georchestra-127-0-0-1.nip.io/my.fqdn/' {} \;
 ```
 ...where `my.fqdn` is your server's FQDN.
 

--- a/default.properties
+++ b/default.properties
@@ -51,7 +51,7 @@ logoUrl=https://www.georchestra.org/public/georchestra-logo.svg
 # Default email address used to send and receive mails in console
 # See the corresponding properties files to override this email
 # address for specific needs.
-administratorEmail=georchestra@georchestra-127-0-1-1.traefik.me
+administratorEmail=georchestra@georchestra-127-0-0-1.nip.io
 
 ### PostgreSQL properties
 

--- a/gateway/security.yaml
+++ b/gateway/security.yaml
@@ -45,7 +45,7 @@ georchestra:
 #            redirect-uri: "{baseUrl}/login/oauth2/code/cas-oauth2"
 #        provider:
 #          cas-oauth2:
-#            authorization-uri: https://georchestra-127-0-1-1.traefik.me/cas/oauth2.0/authorize
-#            token-uri: https://georchestra-127-0-1-1.traefik.me/cas/oauth2.0/accessToken
-#            user-info-uri: https://georchestra-127-0-1-1.traefik.me/cas/oauth2.0/profile
+#            authorization-uri: https://georchestra-127-0-0-1.nip.io/cas/oauth2.0/authorize
+#            token-uri: https://georchestra-127-0-0-1.nip.io/cas/oauth2.0/accessToken
+#            user-info-uri: https://georchestra-127-0-0-1.nip.io/cas/oauth2.0/profile
 #            userNameAttribute: id

--- a/geonetwork/microservices/ogc-api-records/config.yml
+++ b/geonetwork/microservices/ogc-api-records/config.yml
@@ -37,8 +37,8 @@ spring:
       enabled: false
 
 gn:
-  baseurl: https://georchestra-127-0-1-1.traefik.me/geonetwork
-  legacy.url: https://georchestra-127-0-1-1.traefik.me/geonetwork
+  baseurl: https://georchestra-127-0-0-1.nip.io/geonetwork
+  legacy.url: https://georchestra-127-0-0-1.nip.io/geonetwork
   language:
     default: eng
   linkToLegacyGN4: true


### PR DESCRIPTION
Traefik.me availability seems flaky. I would propose to migrate to https://nip.io which has been in service for way longer and is really reliable, at least everytime I have used it was available. nip.io exists since 2012, whereas traefik.me only since 2019