### PR TITLE
update gn-ogc-api-records default config for 4.4.6-1

### DIFF
--- a/geonetwork/microservices/ogc-api-records/config.yml
+++ b/geonetwork/microservices/ogc-api-records/config.yml
@@ -59,6 +59,7 @@ gn:
         responseProcessor: JsonUserAndSelectionAwareResponseProcessorImpl
         operations:
           - root
+          - conformance
           - collections
           - collection
           - items
@@ -74,9 +75,10 @@ gn:
           - item
       - name: json
         mimeType: application/json
-        responseProcessor: JsonUserAndSelectionAwareResponseProcessorImpl
+        responseProcessor: GeoJsonResponseProcessorImpl
         operations:
           - root
+          - conformance
           - collections
           - collection
           - items
@@ -110,6 +112,12 @@ gn:
         responseProcessor: RssResponseProcessorImpl
         operations:
           - items
+      - name : gnindex
+        mimeType : application/gnindex+json
+        responseProcessor : JsonUserAndSelectionAwareResponseProcessorImpl
+        operations :
+          - items
+          - item
       - name : geojson
         mimeType : application/geo+json
         responseProcessor: GeoJsonResponseProcessorImpl


### PR DESCRIPTION
default the f=json output to geojson, add f=gnindex for the ones relying on the ES output format. from geonetwork/geonetwork-microservices#119

adds /conformance, from  geonetwork/geonetwork-microservices#59

with that, GN 4.4.5 and the ogc-api-records microservice from [4.4.6-1](https://github.com/geonetwork/geonetwork-microservices/releases/tag/4.4.6-1) deployed on demo.geor, we have:
- https://demo.georchestra.org/ogc-api-records/collections/main/items?limit=10&f=json returning the same as `f=geojson`
- https://demo.georchestra.org/ogc-api-records/collections/main/items?limit=10&f=gnindex returns what was previously the default for `f=json`
- https://demo.georchestra.org/ogc-api-records/collections/main/items?limit=10&f=rss gives a working RSS feed.