### PR TITLE
console - relocate the competenceAreaEnabled option

### DIFF
--- a/console/console.properties
+++ b/console/console.properties
@@ -159,33 +159,47 @@
 orgTypeValues=Association,Company,NGO,Individual,Other
 
 
+# Activates area of competence
+# if set to true, enables the competence area in the account form and in organization page
+# defaults to false
+# When activated, you should also uncomment and configure the following options:
+# AreaMapCenter, AreaMapZoom, AreasUrl, AreasKey, AreasValue, AreasGroup
+#
+#competenceAreaEnabled=false
+
 # Areas map configuration
 # This map appears on the /console/account/new page, when the user checks the "my org does not exist" checkbox.
 # Currently the map is configured with the EPSG:4326 SRS.
 # Center of map
-AreaMapCenter=9.3707, 42.0753
+#
+#AreaMapCenter=9.3707, 42.0753
 
 # Zoom of map
-AreaMapZoom=7
+#
+#AreaMapZoom=7
 
 # AreasUrl is the URL of a static geojson file in the current folder, which
 # provides the basic geometries used to build up organization's areas.
 # Also accepts an URL, which can be a static file or a WFS request.
 # MUST provide a GeoJSON FeatureCollection with the EPSG:4326 SRS.
 # example "dynamic" AreasUrl=https://my.server.org/geoserver/ows?SERVICE=WFS&REQUEST=GetFeature&typeName=gadm:gadm_for_countries&outputFormat=json&srs=EPSG:4326&cql_filter=ISO='FRA' or ISO='BEL'
-AreasUrl=cities.geojson
+#
+#AreasUrl=cities.geojson
 
 # The following properties are used to configure the map widget behavior:
 # AreasKey is the key stored in the org LDAP record to uniquely identify a feature.
-AreasKey=INSEE_COM
+#
+#AreasKey=INSEE_COM
 
 # AreasValue is the feature "nice name" which appears in the widget list once selected, and in the search result as well.
-AreasValue=NOM_COM_M
+#
+#AreasValue=NOM_COM_M
 
 # AreasGroup is the feature property which is used to group together areas.
 # eg: if the GeoJSON file represents regions, then AreasGroup might be the property with the "state name".
 # CAUTION: AreasGroup **has to** be a string, not a numeric !
-AreasGroup=INSEE_DEP
+#
+#AreasGroup=INSEE_DEP
 
 
 # reCaptcha V2
@@ -353,8 +367,3 @@ AreasGroup=INSEE_DEP
 #pgsqlGNDatabase=georchestra
 #pgsqlGNUser=georchestra
 #pgsqlGNPassword=georchestra
-
-# Activates area of competence
-# if set to true, enable competence area in the account form and in organization page
-# default: false
-# competenceAreaEnabled=false


### PR DESCRIPTION
It's better to have it next to the relevant options