### PR TITLE
Add cors to GW's gn route

### DIFF
--- a/datahub/conf/default.toml
+++ b/datahub/conf/default.toml
@@ -10,7 +10,7 @@ datahub_url = "/datahub"
 # This should point to a proxy to avoid CORS errors on some requests (data preview, OGC capabilities etc.)
 # The actual URL will be appended after this path, e.g. : https://my.proxy/?url=http%3A%2F%2Fencoded.url%2Fows`
 # This is an optional parameter: leave empty to disable proxy usage
-proxy_path = "/proxy/?url="
+proxy_path = "/mapstore/proxy/?url="
 # This optional parameter defines, in which language metadata should be queried in elasticsearch.
 # Use ISO 639-2/B (https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format to indicate the language of the metadata.
 # Setting to "current" will use the current language of the User Interface.

--- a/gateway/routes.yaml
+++ b/gateway/routes.yaml
@@ -28,11 +28,20 @@ spring:
         predicates:
         - Path=/geonetwork/**
         filters:
+        - DedupeResponseHeader=Access-Control-Allow-Origin, RETAIN_FIRST
         - name: CookieAffinity
           args:
             name: XSRF-TOKEN
             from: /geonetwork
             to: /datahub
+        metadata:
+          cors:
+            allowedOrigins: '*'
+            allowedMethods:
+              - GET
+              - POST
+            allowedHeaders: '*'
+            maxAge: 30
       - id: geoserver
         uri: ${georchestra.gateway.services.geoserver.target}
         predicates:


### PR DESCRIPTION
Used to avoid preflight request being forbid by gateway. 

Old problem: (in french) https://groups.google.com/g/georchestra-dev/c/PeXxK1Zz_8I?pli=1

and set proxy to mapstore's for datahub.