### PR TITLE
duplicate the XSRF-TOKEN cookie to /metadata-editor too

### DIFF
--- a/gateway/routes.yaml
+++ b/gateway/routes.yaml
@@ -34,6 +34,11 @@ spring:
             name: XSRF-TOKEN
             from: /geonetwork
             to: /datahub
+        - name: CookieAffinity
+          args:
+            name: XSRF-TOKEN
+            from: /geonetwork
+            to: /metadata-editor
         metadata:
           cors:
             allowedOrigins: '*'

--- a/security-proxy/cookie-mappings.json
+++ b/security-proxy/cookie-mappings.json
@@ -3,5 +3,10 @@
 		"name": "XSRF-TOKEN",
 		"from": "/geonetwork",
 		"to": "/datahub"
+	},
+	{
+		"name": "XSRF-TOKEN",
+		"from": "/geonetwork",
+		"to": "/metadata-editor"
 	}
 ]


### PR DESCRIPTION
allows the metadata editor to authenticate properly against the geonetwork backend, cc @LHBruneton-C2C

found by @f-necas via https://github.com/georchestra/sample-docker-composition/blob/main/geonetwork/metadata-editor/datadir/security-proxy/cookie-mappings.json

tested working fine with the s-p on https://demo.georchestra.org/metadata-editor/ (make sure you remove all cookies first)

as for the gateway variant, i have absolutely zero idea if the route filters thing is an array and supports such 'duplicate' constructs. testing welcome.