### PR TITLE
Update request type whitelists in mapstore's proxy.properties

### DIFF
--- a/mapstore/proxy.properties
+++ b/mapstore/proxy.properties
@@ -35,7 +35,7 @@ methodsWhitelist = GET,POST,PUT
 # only urls matching one of the whitelist will be forwarded
 #reqtypeWhitelist.capabilities = (([&]?([Rr][Ee][Qq][Uu][Ee][Ss][Tt]=[Gg]et[Cc]apabilities))|([&]?(version=1\\.1\\.1)))+
 reqtypeWhitelist.capabilities = .*[Gg]et[Cc]apabilities.*
-reqtypeWhitelist.featureinfo = .*[Gg]et[Ff]eature[Ii]nfo.*
+reqtypeWhitelist.featureinfo = .*[Gg]et[Ff]eature.*
 reqtypeWhitelist.csw = .*csw.*
 reqtypeWhitelist.geostore = .*geostore.*
-reqtypeWhitelist.generic = (.*exist.*)|(.*pdf.*)|(.*map.*)|(.*wms.*)|(.*wmts.*)|(.*wfs.*)|(.*ows.*)
+reqtypeWhitelist.generic = (.*exist.*)|(.*pdf.*)|(.*map.*)|(.*wms.*)|(.*wmts.*)|(.*wfs.*)|(.*ows.*)|(.*geojson.*)|(.*csw.*)|(.*ogcapi.*)|(.*csv.*)


### PR DESCRIPTION
Allow to use csv ogcapi and other trhough mapstore's proxy