### PR TITLE
feat: Add Redis session config

### DIFF
--- a/gateway/application.yaml
+++ b/gateway/application.yaml
@@ -21,3 +21,9 @@ spring:
       filter:
         secure-headers:
           referrer-policy: strict-origin
+  session:
+    redis:
+      enabled: ${SPRING_SESSION_REDIS_ENABLED:false}
+      host: ${SPRING_SESSION_REDIS_HOST:redis}
+      port: ${SPRING_SESSION_REDIS_PORT:6379}
+      password: ${SPRING_SESSION_REDIS_PASSWORD:password}


### PR DESCRIPTION
Related to https://github.com/georchestra/georchestra-gateway/pull/272

In order to have everything automatically configured in a docker environment.

The envs are for now configured in Kubernetes in the helm chart: https://github.com/georchestra/helm-charts/pull/226