### PR TITLE
fix: update proxy_path to /proxy for standalone http-proxy deployment

### DIFF
--- a/datahub/conf/default.toml
+++ b/datahub/conf/default.toml
@@ -19,7 +19,7 @@ datahub_url = "/datahub"
 # This should point to a proxy to avoid CORS errors on some requests (data preview, OGC capabilities etc.)
 # The actual URL will be appended after this path, e.g. : https://my.proxy/?url=http%3A%2F%2Fencoded.url%2Fows`
 # This is an optional parameter: leave empty to disable proxy usage
-proxy_path = "/mapstore/proxy/?url="
+proxy_path = "/proxy/?url="
 
 # This optional parameter defines, in which language metadata should be queried in elasticsearch.
 # Use ISO 639-1 (https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format in 2 characters to indicate the language of the metadata.

--- a/metadata-editor/conf/default.toml
+++ b/metadata-editor/conf/default.toml
@@ -19,7 +19,7 @@ datahub_url = "/datahub"
 # This should point to a proxy to avoid CORS errors on some requests (data preview, OGC capabilities etc.)
 # The actual URL will be appended after this path, e.g. : https://my.proxy/?url=http%3A%2F%2Fencoded.url%2Fows`
 # This is an optional parameter: leave empty to disable proxy usage
-proxy_path = "/mapstore/proxy/?url="
+proxy_path = "/proxy/?url="
 
 # This optional parameter defines, in which language metadata should be queried in elasticsearch.
 # Use ISO 639-1 (https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format in 2 characters to indicate the language of the metadata.


### PR DESCRIPTION
There is now a fork of the http-proxy at https://github.com/georchestra/http-proxy (originally from geosolutions-it/http-proxy), in order to have a standalone http-proxy ready to be deployed independently.

Previously, the proxy was served as a sub-path of the MapStore application at /mapstore/proxy. With the standalone deployment, the proxy is now available directly at /proxy.

Update the default proxy_path configuration in datahub and metadata-editor to reflect this new deployment path.